### PR TITLE
Adjustments for README and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ At this stage, TrialMatchAI is still under active development and largely a **pr
    - Launches indexing pipelines in the background  
    - **Estimated Time**: ~60–90 minutes (depending on hardware)  
 
+6. **(Optional) Using Flash-Attention 2**
+   If you want to use Flash-Attention for faster and more memory efficient attention, you can install it through pip, as presented in the [package github](https://github.com/Dao-AILab/flash-attention). 
+
+   For some systems however, installing it with standard methods is either impossible or too slow. It is recommended in this case to manually download the **wheel** file compatible with your torch, cuda and python versions, listed in the package [releases](https://github.com/Dao-AILab/flash-attention/releases). Then, you can pip install that file.
+
 ---
 
 ## 🎯 Usage Example

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ At this stage, TrialMatchAI is still under active development and largely a **pr
 
 - **OS**: Linux or macOS
 - **Docker & Docker Compose**: For running the Elasticsearch container
+- **Java**: For running the NER and Normalization
 - **Python**: ≥ 3.8
 - **GPU**: NVIDIA (e.g., H100) with ≥ 60 GB VRAM (recommended for large-scale processing)
 - **Disk Space**: ≥ 100 GB free (for data and indices)

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,4 @@ langchain-core==0.3.35
 langchain-community==0.3.17
 langchain-openai==0.3.5
 langsmith==0.2.11
+huggingface_hub==0.34.4

--- a/setup.sh
+++ b/setup.sh
@@ -108,9 +108,9 @@ fi
 cd ..
 
 # Extract resources
-info "Extracting resources into src/Parser..."
-mkdir -p src/Parser
-tar -xzvf data/"$RESOURCES_ARCHIVE" -C src/Parser
+info "Extracting resources into source/Parser..."
+mkdir -p source/Parser
+tar -xzvf data/"$RESOURCES_ARCHIVE" -C source/Parser
 
 info "Extracting models into models/..."
 mkdir -p models
@@ -141,7 +141,7 @@ fi
 cd ..
 
 # 4) Launch indexers in background
-cd src/Indexer
+cd utils/Indexer
 info "Starting index_criteria.py (trials_eligibility) ..."
 nohup python index_criteria.py \
   --config           config.json \


### PR DESCRIPTION
This small PR has 4 commits : 
- updated setup directories (namely src -> source, and src/Indexer -> utils/Indexer)
- added huggingface_hub to requirements for downloading base models if needed
- added mentions in README (for Java even though this should not be an issue for most users, and an explicit guideline for Flash-Attention 2, as I've personally had to download the .whl manually like I explain in the README to make it work)