### PR TITLE
Fix dependency resolution and update to stable PyTorch releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,16 +7,16 @@ name = "TrialMatchAI"
 version = "0.1.0"
 description = "AI-driven clinical trial matching pipeline."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10,<3.12"
 license = {file = "LICENSE"}
 dependencies = [
   # Core ML / NLP
-  "torch==2.9.0.dev20250803+cu128",
-  "torchvision==0.24.0.dev20250803+cu128",
-  "torchaudio==2.8.0.dev20250803+cu128",
-  "transformers==4.54.1",
+  "torch==2.7.1",
+  "torchvision==0.22.1",
+  "torchaudio==2.7.1",
+  "transformers==4.55.0",
   "accelerate==1.8.1",
-  "tokenizers==0.21.0",
+  "tokenizers==0.21.1",
   "safetensors==0.5.3",
   "sentence-transformers==2.7.0",
   "sentencepiece==0.2.0",
@@ -49,10 +49,10 @@ dependencies = [
   "gliner==0.2.16",
   # App / infra
   "SQLAlchemy==2.0.37",
-  "pydantic==2.10.6",
+  "pydantic==2.11.7",
   "pydantic-settings==2.7.1",
-  # Optional APIs (keep only if used)
-  "openai==1.62.0",
+  # Optional APIs
+  "openai==1.99.1",
   "httpx==0.28.1",
   "langchain==0.3.18",
   "langchain-core==0.3.35",
@@ -77,3 +77,16 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["source"]
+
+[tool.uv]
+index-url = "https://pypi.org/simple"
+
+[[tool.uv.index]]
+name = "pytorch-cuda"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
+[tool.uv.sources]
+torch = { index = "pytorch-cuda" }
+torchvision = { index = "pytorch-cuda" }
+torchaudio = { index = "pytorch-cuda" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
+--extra-index-url https://download.pytorch.org/whl/cu128
+
 # Core ML / NLP
-torch==2.9.0.dev20250803+cu128
-torchvision==0.24.0.dev20250803+cu128
-torchaudio==2.8.0.dev20250803+cu128
-transformers==4.54.1
+torch==2.7.1
+torchvision==0.22.1
+torchaudio==2.7.1
+transformers==4.55.0
 accelerate==1.8.1
-tokenizers==0.21.0
+tokenizers==0.21.1
 safetensors==0.5.3
 sentence-transformers==2.7.0
 sentencepiece==0.2.0
@@ -15,6 +17,13 @@ einops==0.8.0
 tiktoken==0.8.0
 bitsandbytes==0.46.1
 vllm==0.10.1.1
+
+# vllm dependencies (pin to avoid backtracking)
+fastapi>=0.115.0
+uvicorn[standard]>=0.30.0
+dnspython>=2.6.0
+email-validator>=2.0.0
+
 # Classical stack & utilities
 numpy==1.26.4
 scipy==1.15.1
@@ -39,11 +48,11 @@ gliner==0.2.16
 
 # App / infra
 SQLAlchemy==2.0.37
-pydantic==2.10.6
+pydantic==2.11.7
 pydantic-settings==2.7.1
 
-# Optional APIs (keep only if used)
-openai==1.62.0
+# Optional APIs
+openai==1.99.1
 httpx==0.28.1
 langchain==0.3.18
 langchain-core==0.3.35


### PR DESCRIPTION
- Switch to stable pytorch 2.7.1 (was nightly 2.9.0.dev) while maintaining CUDA 12.8
- Adjusted conflicting packages
- Restrict python to >=3.10, <3.12 (was >=3.8)
- Added uv package manager support

These changes were made because the nightly torch version does not exist anymore in pytorch repositories, so a switch to a prior stable release is favorable.

medspacy==1.3.1 has conflicting spacy requirements across python versions (>3.12 requires spacy<3.8, while >=3.12 requires spacy >=3.8) , so restricting allows using the original version spacy==3.7.5. 
Additionally, vllm==0.10.1.1 doesn't support python 3.13. 

Both uv and pip were tested using the commands pip install and uv sync for python 3.11.