### PR TITLE
fix(P0): four shipping bugs from the test/codebase audit

### DIFF
--- a/src/trialmatchai/cli/build.py
+++ b/src/trialmatchai/cli/build.py
@@ -75,18 +75,13 @@ def main() -> int:
         logger.error("Build aborted: resolve the %s issue(s) above.", len(preflight_issues))
         return 1
 
-    build_system(
-        config,
-        trials_json_folder=args.trials_json_folder,
-        processed_trials_folder=args.processed_trials_folder,
-        processed_criteria_folder=args.processed_criteria_folder,
-        force_prepare=args.force_prepare,
-        force_reindex=args.reindex,
-    )
-
-    # Optional: chain the concept-DB build. --concepts pulls the open vocabularies
-    # (auto-downloaded); --concepts-csv adds the licensed OMOP vocab on top.
-    if args.concepts or args.concepts_csv:
+    # Build the concept store BEFORE prepare/index. --concepts pulls the open
+    # vocabularies (auto-downloaded); --concepts-csv adds the licensed OMOP vocab.
+    # Building it first means `build_system` can link the extracted entities
+    # between prepare and index, so the search tables carry concept IDs instead of
+    # leaving every entity at concept_store_unavailable.
+    link_concepts = bool(args.concepts or args.concepts_csv)
+    if link_concepts:
         logger.info("=== build: concepts stage ===")
         from trialmatchai.cli.build_concepts import run_build_concepts
 
@@ -102,6 +97,16 @@ def main() -> int:
             "Run `trialmatchai build --concepts` to enable it (open vocabularies, "
             "auto-downloaded); add --concepts-csv for OMOP SNOMED/LOINC/RxNorm."
         )
+
+    build_system(
+        config,
+        trials_json_folder=args.trials_json_folder,
+        processed_trials_folder=args.processed_trials_folder,
+        processed_criteria_folder=args.processed_criteria_folder,
+        force_prepare=args.force_prepare,
+        force_reindex=args.reindex,
+        link_concepts=link_concepts,
+    )
 
     state = build_state(
         config,

--- a/src/trialmatchai/interop/importers/omop.py
+++ b/src/trialmatchai/interop/importers/omop.py
@@ -22,6 +22,9 @@ from trialmatchai.interop.utils import (
     safe_patient_id,
     source_path_string,
 )
+from trialmatchai.utils.logging_config import setup_logging
+
+logger = setup_logging(__name__)
 
 
 def import_omop_extract(
@@ -30,7 +33,7 @@ def import_omop_extract(
     strict: bool = False,
 ) -> list[PatientProfile]:
     root = Path(path)
-    tables = _load_tables(root)
+    tables = _load_tables(root, strict=strict)
     concepts = _concept_lookup(tables.get("concept"))
     location_index = _location_index(tables.get("location"))
     person = tables.get("person")
@@ -90,16 +93,23 @@ def import_omop_extract(
     return profiles
 
 
-def _load_tables(root: Path) -> dict[str, pd.DataFrame]:
+def _load_tables(root: Path, *, strict: bool = False) -> dict[str, pd.DataFrame]:
     tables: dict[str, pd.DataFrame] = {}
     for file_path in root.iterdir():
         if file_path.suffix.casefold() not in {".csv", ".parquet"}:
             continue
         name = file_path.stem.casefold()
-        if file_path.suffix.casefold() == ".csv":
-            table = pd.read_csv(file_path)
-        else:
-            table = pd.read_parquet(file_path)
+        try:
+            if file_path.suffix.casefold() == ".csv":
+                table = pd.read_csv(file_path)
+            else:
+                table = pd.read_parquet(file_path)
+        except Exception:
+            # A single malformed table must not abort the whole import.
+            logger.warning("OMOP: failed to read %s; skipping", file_path, exc_info=True)
+            if strict:
+                raise
+            continue
         table.columns = [str(column).casefold() for column in table.columns]
         tables[name] = table
     return tables
@@ -290,7 +300,10 @@ def _add_note_nlp_rows(
                 provenance=_row_provenance(root, profile.patient_id, "NOTE_NLP"),
                 evidence_text=clean_text(row.get("snippet")) or None,
                 evidence_start=_int_or_none(row.get("offset")),
-                negated=str(row.get("term_exists")).casefold() == "false",
+                # OMOP note_nlp.term_exists marks whether the term is asserted:
+                # "N"/"No"/"0"/"False" mean it is NEGATED (e.g. "no metastasis").
+                negated=str(row.get("term_exists")).strip().casefold()
+                in {"n", "no", "false", "0", "f"},
             )
         )
 

--- a/src/trialmatchai/interop/importers/phenopacket.py
+++ b/src/trialmatchai/interop/importers/phenopacket.py
@@ -16,6 +16,9 @@ from trialmatchai.interop.utils import (
     source_path_string,
 )
 from trialmatchai.schemas.phenopacket import Phenopacket
+from trialmatchai.utils.logging_config import setup_logging
+
+logger = setup_logging(__name__)
 
 
 def import_phenopacket(
@@ -41,14 +44,30 @@ def import_phenopacket(
         demographics=_demographics(data.get("subject") or {}),
         provenance=[provenance],
     )
-    _add_phenotypes(profile, data, provenance)
-    _add_diseases(profile, data, provenance)
-    _add_biosamples(profile, data, provenance)
-    _add_measurements(profile, data, provenance)
-    _add_actions(profile, data, provenance)
-    _add_interpretations(profile, data, provenance)
-    _add_family(profile, data, provenance)
-    _add_files(profile, data, provenance)
+    # Isolate each section: a single malformed item (e.g. a string where an
+    # ontology-class object is expected) must not abort the whole import in
+    # non-strict mode — only re-raise when strict.
+    for add_section in (
+        _add_phenotypes,
+        _add_diseases,
+        _add_biosamples,
+        _add_measurements,
+        _add_actions,
+        _add_interpretations,
+        _add_family,
+        _add_files,
+    ):
+        try:
+            add_section(profile, data, provenance)
+        except Exception:
+            logger.warning(
+                "phenopacket: section %s failed for %s; skipping",
+                add_section.__name__,
+                patient_id,
+                exc_info=True,
+            )
+            if strict:
+                raise
     return profile
 
 

--- a/src/trialmatchai/matching/trial_ranker.py
+++ b/src/trialmatchai/matching/trial_ranker.py
@@ -46,26 +46,37 @@ def load_trial_data(
 # by the fraction of decided inclusion criteria (Met or Not Met) that are Met.
 DISQUALIFIED_SCORE = -1.0
 
-_DECIDED_INCLUSION = {"Met", "Not Met"}
+_DECIDED_INCLUSION = {"met", "not met"}
+
+# Model classifications vary in case, surrounding markdown, and trailing
+# punctuation (e.g. "violated", "**Violated**", "Met."); normalize before matching
+# so a disqualifying exclusion is never missed on a formatting variant.
+_CLASSIFICATION_STRIP = " \t\r\n*_`.,;:!\"'"
+
+
+def _normalize_classification(value: object) -> str:
+    return value.strip(_CLASSIFICATION_STRIP).casefold() if isinstance(value, str) else ""
 
 
 def score_trial(trial: Dict) -> float:
     inclusion = [
-        c.get("Classification") for c in trial.get("Inclusion_Criteria_Evaluation", [])
+        _normalize_classification(c.get("Classification"))
+        for c in trial.get("Inclusion_Criteria_Evaluation", [])
     ]
     exclusion = [
-        c.get("Classification") for c in trial.get("Exclusion_Criteria_Evaluation", [])
+        _normalize_classification(c.get("Classification"))
+        for c in trial.get("Exclusion_Criteria_Evaluation", [])
     ]
 
     # Any violated exclusion is a hard disqualifier: rank below all eligible trials.
-    if "Violated" in exclusion:
+    if "violated" in exclusion:
         return DISQUALIFIED_SCORE
 
     # Eligible: score by the fraction of decided inclusion criteria that are Met.
     decided = [c for c in inclusion if c in _DECIDED_INCLUSION]
     if not decided:
         return 0.0
-    met = sum(1 for c in decided if c == "Met")
+    met = sum(1 for c in decided if c == "met")
     return met / len(decided)
 
 

--- a/src/trialmatchai/orchestration.py
+++ b/src/trialmatchai/orchestration.py
@@ -471,8 +471,9 @@ def build_system(
     processed_criteria_folder: str | Path = "data/processed_criteria",
     force_prepare: bool = False,
     force_reindex: bool = False,
+    link_concepts: bool = False,
 ) -> dict:
-    """Run the setup half (prepare -> index), idempotent, with a manifest.
+    """Run the setup half (prepare -> link -> index), idempotent, with a manifest.
 
     Each stage is resumable and recorded in ``.trialmatchai_build.json`` next to
     the processed data, so a disrupted build can be re-run and continues from the
@@ -511,6 +512,20 @@ def build_system(
             "normalized trial JSONs."
         )
     _save_manifest(manifest_path, manifest)
+
+    # Stage 1b — link extracted entities to concept IDs when a concept store was
+    # built this run, so the index carries concept IDs instead of leaving every
+    # entity at concept_store_unavailable. Idempotent: already-linked entities are
+    # skipped, so this also relinks an already-prepared NER-only corpus.
+    if link_concepts:
+        logger.info("=== build: link stage ===")
+        from trialmatchai.linking import link_corpus
+
+        link_tally = link_corpus(
+            config, processed_criteria_folder=pc, processed_trials_folder=pt
+        )
+        manifest["link"] = {**link_tally, "completed_at": _now_iso()}
+        _save_manifest(manifest_path, manifest)
 
     # Stage 2 — build the LanceDB search index (idempotent).
     logger.info("=== build: index stage ===")

--- a/tests/test_patient_interop.py
+++ b/tests/test_patient_interop.py
@@ -345,3 +345,75 @@ def test_narrative_and_phenopacket_export_are_deterministic(tmp_path):
     assert narrative[0].startswith("Diagnoses:")
     assert packet_out["id"] == "patient-export"
     assert packet_out["diseases"][0]["term"]["label"] == "cancer"
+
+
+def test_omop_note_nlp_negation_recognizes_no(tmp_path):
+    """OMOP note_nlp.term_exists 'N'/'No'/'0' means the term is negated (e.g.
+    'no metastasis'); only literal 'false' was honored before (audit P0)."""
+    from trialmatchai.interop.importers.omop import import_omop_extract
+
+    omop = tmp_path / "omop"
+    omop.mkdir()
+    pd.DataFrame([{"person_id": 1, "gender_source_value": "F", "year_of_birth": 1980}]).to_csv(
+        omop / "PERSON.csv", index=False
+    )
+    pd.DataFrame(
+        [
+            {"person_id": 1, "note_nlp_concept_id": 10, "term_exists": "N", "snippet": "no metastasis"},
+            {"person_id": 1, "note_nlp_concept_id": 11, "term_exists": "Y", "snippet": "diabetes present"},
+        ]
+    ).to_csv(omop / "NOTE_NLP.csv", index=False)
+    pd.DataFrame(
+        [
+            {"concept_id": 10, "vocabulary_id": "SNOMED", "concept_code": "1", "concept_name": "Metastasis", "domain_id": "Condition"},
+            {"concept_id": 11, "vocabulary_id": "SNOMED", "concept_code": "2", "concept_name": "Diabetes", "domain_id": "Condition"},
+        ]
+    ).to_csv(omop / "CONCEPT.csv", index=False)
+
+    profile = import_omop_extract(omop)[0]
+    by_label = {c.label: c for c in profile.conditions}
+    assert by_label["Metastasis"].negated is True
+    assert by_label["Diabetes"].negated is False
+
+
+def test_omop_import_isolates_unreadable_table(tmp_path):
+    """A single unreadable OMOP table must not abort the whole import in
+    non-strict mode, but must raise in strict mode (audit P0)."""
+    import pytest
+
+    from trialmatchai.interop.importers.omop import import_omop_extract
+
+    omop = tmp_path / "omop"
+    omop.mkdir()
+    pd.DataFrame([{"person_id": 1, "gender_source_value": "F", "year_of_birth": 1980}]).to_csv(
+        omop / "PERSON.csv", index=False
+    )
+    (omop / "EXTRA.parquet").write_bytes(b"not a real parquet file")
+
+    profiles = import_omop_extract(omop)  # non-strict: person imports, bad table skipped
+    assert len(profiles) == 1
+    with pytest.raises(Exception):  # strict: malformed table aborts
+        import_omop_extract(omop, strict=True)
+
+
+def test_phenopacket_import_isolates_malformed_section(tmp_path):
+    """A malformed phenotypicFeatures item must not abort the whole import in
+    non-strict mode, but must raise in strict mode (audit P0)."""
+    import pytest
+
+    from trialmatchai.interop.importers.phenopacket import import_phenopacket
+
+    packet = {
+        "id": "P1",
+        "subject": {"sex": "FEMALE"},
+        "phenotypicFeatures": ["should be an object, not a string"],
+        "diseases": [{"term": {"id": "DOID:1612", "label": "breast cancer"}}],
+    }
+    path = tmp_path / "p.json"
+    path.write_text(json.dumps(packet), encoding="utf-8")
+
+    profile = import_phenopacket(path)  # non-strict: bad section skipped, rest imports
+    assert profile.patient_id == "P1"
+    assert any(c.label == "breast cancer" for c in profile.conditions)
+    with pytest.raises(Exception):
+        import_phenopacket(path, strict=True)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -94,3 +94,35 @@ def test_run_pipeline_frees_models_even_on_stage_error(monkeypatch):
     with pytest.raises(RuntimeError):
         pipeline.run_pipeline(StageContext(config={}))
     assert freed == [1]  # GPU freed despite the failure
+
+
+def test_build_system_links_between_prepare_and_index(monkeypatch, tmp_path):
+    """build --concepts must run the link stage AFTER prepare and BEFORE index so
+    the search tables carry concept IDs, not concept_store_unavailable (audit P0)."""
+    from trialmatchai import orchestration as orch
+    import trialmatchai.linking as linking
+
+    calls = []
+    src = tmp_path / "trials_jsons"
+    src.mkdir()
+    (src / "NCT1.json").write_text("{}", encoding="utf-8")  # so the prepare stage runs
+
+    monkeypatch.setattr(orch, "prepare_corpus", lambda *a, **k: calls.append("prepare") or {"prepared": 0})
+    monkeypatch.setattr(linking, "link_corpus", lambda *a, **k: calls.append("link") or {"accepted": 0})
+    monkeypatch.setattr(orch, "build_index", lambda *a, **k: calls.append("index") or {"trials": 0})
+    monkeypatch.setattr(orch, "build_state", lambda *a, **k: {"ready_to_match": True})
+
+    orch.build_system(
+        {"paths": {}}, trials_json_folder=src,
+        processed_trials_folder=tmp_path / "pt", processed_criteria_folder=tmp_path / "pc",
+        link_concepts=True,
+    )
+    assert calls == ["prepare", "link", "index"]
+
+    calls.clear()
+    orch.build_system(
+        {"paths": {}}, trials_json_folder=src,
+        processed_trials_folder=tmp_path / "pt2", processed_criteria_folder=tmp_path / "pc2",
+        link_concepts=False,
+    )
+    assert calls == ["prepare", "index"]

--- a/tests/test_trial_ranker_scoring_contract.py
+++ b/tests/test_trial_ranker_scoring_contract.py
@@ -82,3 +82,29 @@ def test_disqualified_ranks_below_even_a_zero_score_eligible_trial():
     ranked = rank_trials([TRIAL_VIOLATED_EXCLUSION, TRIAL_ALL_NOT_MET])
     assert ranked[0]["TrialID"] == "NOT_MET"
     assert ranked[-1]["TrialID"] == "VIOLATED"
+
+
+def test_score_trial_normalizes_classification_variants():
+    """Model output varies in case, markdown, and trailing punctuation; a
+    disqualifying Violated exclusion must still be detected (audit P0)."""
+    for variant in ("violated", "**Violated**", "Violated ", "Violated.", "VIOLATED"):
+        trial = {
+            "Inclusion_Criteria_Evaluation": [{"Classification": "Met"}],
+            "Exclusion_Criteria_Evaluation": [{"Classification": variant}],
+        }
+        assert score_trial(trial) == DISQUALIFIED_SCORE, variant
+
+    # "Not Violated" must NOT disqualify (substring trap), and inclusion variants
+    # in mixed case / whitespace must still count toward the Met fraction.
+    assert score_trial(
+        {
+            "Inclusion_Criteria_Evaluation": [{"Classification": "met"}],
+            "Exclusion_Criteria_Evaluation": [{"Classification": "Not Violated"}],
+        }
+    ) == 1.0
+    assert score_trial(
+        {
+            "Inclusion_Criteria_Evaluation": [{"Classification": "MET"}, {"Classification": "not met "}],
+            "Exclusion_Criteria_Evaluation": [],
+        }
+    ) == 0.5


### PR DESCRIPTION
1. score_trial: normalize LLM classifications before matching (matching/trial_ranker.py). Exact-string 'Violated'/'Met' missed case/markdown/ whitespace variants ('violated','**Violated**','Violated '), so a disqualifying exclusion could be ignored and an ineligible patient outrank a disqualified trial. Now strip markdown/edge-punctuation + casefold; 'Not Violated' still does not disqualify.

2. build --concepts: link entities before indexing (cli/build.py + orchestration.build_system). build_system ran prepare->index and the concept store was built afterwards, so the index held entities at concept_store_unavailable and linking never happened. Build the concept store first and add a link stage (link_concepts) that runs link_corpus between prepare and index (idempotent -> also relinks an already-prepared NER corpus).

3. OMOP note_nlp negation (interop/importers/omop.py). Only literal 'false' negated; real CDM term_exists='N' -> 'no metastasis' was imported as present. Now negate on {n,no,false,0,f}.

4. Import failure isolation (interop/importers/omop.py + phenopacket.py). One malformed table/section aborted the whole import even in non-strict mode. OMOP _load_tables now skips unreadable tables per-file (raises only in strict); the phenopacket importer isolates each section (raises only in strict).

Tests: one reproduction test per fix (classification variants; build stage order; note_nlp negation truth set; OMOP + phenopacket isolation strict-vs-non-strict). Full suite green (213).