### PR TITLE
fix: four medium-severity audit bugs (nDCG, OMOP zero, topic sex, age range)

### DIFF
--- a/src/trialmatchai/interop/importers/omop.py
+++ b/src/trialmatchai/interop/importers/omop.py
@@ -171,7 +171,10 @@ def _add_measurement_rows(
                     label=label,
                     original_code=code,
                     provenance=_row_provenance(root, profile.patient_id, "MEASUREMENT"),
-                    description=clean_text(f"{value or ''} {unit or ''}") or None,
+                    description=clean_text(
+                        f"{value if value is not None else ''} {unit or ''}"
+                    )
+                    or None,
                     temporality=clean_text(row.get("measurement_date")) or None,
                 )
             )

--- a/src/trialmatchai/matching/retrieval/trial_retrieval.py
+++ b/src/trialmatchai/matching/retrieval/trial_retrieval.py
@@ -43,16 +43,21 @@ class ClinicalTrialSearch:
 
     def parse_age_input(self, age_input: Union[int, str]) -> Optional[int]:
         if isinstance(age_input, int):
-            return age_input
+            return age_input if 0 <= age_input <= 150 else None
         elif isinstance(age_input, str):
             age_input = age_input.strip().lower()
             age_keywords = ["year", "years", "yr", "yrs"]
             try:
+                age_str = age_input
                 for keyword in age_keywords:
                     if age_input.endswith(keyword):
                         age_str = age_input.replace(keyword, "").strip()
-                        return int(age_str)
-                return int(age_input)
+                        break
+                parsed = int(age_str)
+                # A purely-numeric age is authoritative: accept it when in range,
+                # else reject. Do NOT fall through to fuzzy date parsing, which
+                # would misread "-5" as a near-today date (age 0).
+                return parsed if 0 <= parsed <= 150 else None
             except ValueError:
                 pass
             try:

--- a/src/trialmatchai/trec/metrics.py
+++ b/src/trialmatchai/trec/metrics.py
@@ -39,6 +39,10 @@ def tie_aware_dcg_at_k(
     scores are contiguous. Each tie group spanning 1-indexed ranks [a..b] gives
     every member the mean discount over ranks a..min(b, k).
     """
+    # Enforce the by-descending-score precondition so tie groups are contiguous
+    # regardless of how the caller ordered the list (the metric is tie-order
+    # invariant, so a stable re-sort cannot change a correct result).
+    ordered_ids = sorted(ordered_ids, key=lambda d: score_of.get(d, 0.0), reverse=True)
     n = len(ordered_ids)
     total = 0.0
     i = 0

--- a/src/trialmatchai/trec/topics.py
+++ b/src/trialmatchai/trec/topics.py
@@ -176,11 +176,16 @@ def extract_demographics(text: str) -> tuple[float | None, str | None]:
             if 0 < value <= 120:
                 age = float(value)
                 break
-    # Female check first: "male" is a substring concern handled by word bounds.
+    # Pick whichever sex mention appears FIRST: the subject is named before any
+    # relatives/partners, so this avoids "a man with a female partner" -> Female.
     sex: str | None = None
-    if _FEMALE.search(text):
+    fm = _FEMALE.search(text)
+    mm = _MALE.search(text)
+    if fm and mm:
+        sex = "Female" if fm.start() < mm.start() else "Male"
+    elif fm:
         sex = "Female"
-    elif _MALE.search(text):
+    elif mm:
         sex = "Male"
     return age, sex
 

--- a/tests/test_medium_bug_fixes.py
+++ b/tests/test_medium_bug_fixes.py
@@ -1,0 +1,72 @@
+"""Reproduction tests for the medium-severity bugs found in the codebase audit.
+
+Each test fails on the pre-fix code and passes on the fix.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_tie_aware_ndcg_is_input_order_invariant():
+    # The tie-aware nDCG groups equal-score items; it must not depend on whether
+    # the caller handed in a score-sorted list. Ties (b, c) are interleaved below.
+    from trialmatchai.trec.metrics import condensed_ndcg, ndcg_at_k
+
+    score = {"a": 0.9, "b": 0.5, "c": 0.5, "d": 0.1}
+    gain = {"a": 2, "b": 0, "c": 3, "d": 1}
+    by_score = ["a", "b", "c", "d"]
+    interleaved = ["c", "a", "d", "b"]  # same items, tie group not contiguous
+
+    assert ndcg_at_k(by_score, score, gain, 4) == pytest.approx(
+        ndcg_at_k(interleaved, score, gain, 4)
+    )
+    assert condensed_ndcg(by_score, score, gain, [4]) == condensed_ndcg(
+        interleaved, score, gain, [4]
+    )
+
+
+def test_omop_measurement_keeps_zero_value():
+    # A measurement of exactly 0 (e.g. a count, a delta) must be retained, not
+    # silently dropped by an `x or ''` falsiness check.
+    from trialmatchai.interop.importers.omop import _add_measurement_rows
+    from trialmatchai.interop.models import PatientProfile
+
+    profile = PatientProfile(patient_id="P1")
+    rows = [
+        {
+            "measurement_concept_id": "",
+            "value_as_number": 0,
+            "unit_concept_id": "",
+            "value_as_concept_id": "",
+            "measurement_date": "2020-01-01",
+            "measurement_source_value": "glucose delta",
+        }
+    ]
+    _add_measurement_rows(profile, rows, {}, Path("."))
+    assert profile.observations
+    assert "0" in (profile.observations[0].description or "")
+
+
+def test_topic_sex_uses_first_mention():
+    # The subject is named before any relative/partner, so the first sex mention
+    # wins — previously Female always won regardless of position.
+    from trialmatchai.trec.topics import extract_demographics
+
+    _, sex = extract_demographics("A 45-year-old man with a female partner seeks care.")
+    assert sex == "Male"
+    _, sex2 = extract_demographics("A 30-year-old woman whose husband is male.")
+    assert sex2 == "Female"
+
+
+def test_parse_age_input_rejects_out_of_range():
+    from trialmatchai.matching.retrieval.trial_retrieval import ClinicalTrialSearch
+
+    search = ClinicalTrialSearch.__new__(ClinicalTrialSearch)
+    assert search.parse_age_input("45") == 45
+    assert search.parse_age_input("45 years") == 45
+    assert search.parse_age_input("-5") is None  # was: -5
+    assert search.parse_age_input(-5) is None  # int branch guarded too
+    assert search.parse_age_input(200) is None


### PR DESCRIPTION
Fixes the four **medium-severity** latent bugs surfaced by the codebase audit, each with a reproduction test (`tests/test_medium_bug_fixes.py`) that fails pre-fix.

| Bug | Site | Fix |
|---|---|---|
| Tie-aware nDCG was order-dependent | `trec/metrics.py` | `tie_aware_dcg_at_k` re-sorts by descending score internally; tie groups are contiguous regardless of caller order. A reranker interleaving equal scores previously corrupted every nDCG. |
| Zero-valued measurement dropped | `interop/importers/omop.py` | `value or ''` discards a reading of `0`; now `value if value is not None else ''`. |
| Sex always resolved to Female | `trec/topics.py` | Takes the **first** sex mention (the subject) — `"a 45-year-old man with a female partner"` → Male. |
| Negative/absurd ages accepted | `matching/retrieval/trial_retrieval.py` | `parse_age_input` rejects out-of-range ages on both branches; numeric input is authoritative (no fuzzy-date fallthrough that read `"-5"` as age 0). |

Full suite green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
