### PR TITLE
trec: deepen analysis funnel to 1000/500/250 (configurable second->CoT thinning)

### DIFF
--- a/src/trialmatchai/config/settings.py
+++ b/src/trialmatchai/config/settings.py
@@ -141,6 +141,10 @@ class SearchSettings(BaseModel):
     vector_score_threshold: float = Field(0.5, ge=0.0, le=1.0)
     max_trials_first_level: int = Field(1000, ge=1)
     max_trials_second_level: int = Field(100, ge=1)
+    # Keep the top 1/N of the reranked second-level trials before CoT (N=1 keeps
+    # all of them). The interactive default thins to a third; the TREC preset sets
+    # N=1 so the full reranked set feeds the CoT cap.
+    second_level_keep_divisor: int = Field(3, ge=1)
     first_level: FirstLevelSearchSettings = Field(
         default_factory=FirstLevelSearchSettings
     )

--- a/src/trialmatchai/main.py
+++ b/src/trialmatchai/main.py
@@ -215,7 +215,8 @@ def run_second_level_search(
         combined_scores[trial_id] = first_score + second_score
 
     sorted_trials = sorted(combined_scores.items(), key=lambda x: x[1], reverse=True)
-    num_top = max(1, min(len(sorted_trials) // 3, top_n))
+    keep_divisor = max(1, int(config.get("search", {}).get("second_level_keep_divisor", 3)))
+    num_top = max(1, min(len(sorted_trials) // keep_divisor, top_n))
     semi_final_trials = sorted_trials[:num_top]
 
     top_trials_path = f"{output_folder}/top_trials.txt"

--- a/src/trialmatchai/trec/runner.py
+++ b/src/trialmatchai/trec/runner.py
@@ -40,6 +40,15 @@ def _track_config(base_config: Dict[str, Any], spec: TrackSpec) -> Dict[str, Any
     cfg["patient_inputs"]["summary_dir"] = str(spec.summary_dir)
     cfg.setdefault("paths", {})["output_dir"] = str(spec.output_dir)
     cfg.setdefault("query_expansion", {})["enabled"] = True
+    # TREC analysis funnel: 1000 (first-level) -> 500 (rerank) -> 250 (CoT), with
+    # no second->CoT thinning (keep_divisor=1) so the full reranked set feeds the
+    # CoT cap. Deeper than the interactive single-patient defaults (which stay at
+    # the config.json values) because TREC scores the whole ranked list per topic.
+    search = cfg.setdefault("search", {})
+    search["max_trials_first_level"] = 1000
+    search["max_trials_second_level"] = 500
+    search["second_level_keep_divisor"] = 1
+    cfg.setdefault("rag", {})["max_trials_rag"] = 250
     return cfg
 
 


### PR DESCRIPTION
Deepens the TREC analysis funnel and makes the second→CoT thinning configurable.

**Funnel: 1000 → 500 → 250** (was 1000 → 100 → 20). The `trec` preset (`_track_config`) now sets `max_trials_second_level=500`, `max_trials_rag=250`, and a new `search.second_level_keep_divisor` to `1` so the full reranked set feeds the CoT cap. CoT now reasons over **250 trials/topic** instead of 20.

- New `SearchSettings.second_level_keep_divisor` (default **3**) — interactive single-patient matching is **unchanged** (still thins to a third → cheap). Only the TREC preset overrides it to 1.
- `main.py` reads the divisor instead of a hardcoded `// 3`.
- Verified: `first=1000 → rerank=500 → semi_final=500 → CoT=250`; full suite green, ruff clean.

Note: the companion `--concepts` fix to `scripts/run_trec_from_scratch.slurm` (so the link stage actually runs) is a **local, gitignored** run-script change and is not in this diff.
