### PR TITLE
release: 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to TrialMatchAI are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.3.0] — 2026-06-30
+
+Adds a clinician-facing results report and deepens retrieval, on top of bug
+fixes and broader test coverage from the 0.2.0 deployment-readiness release.
+
+### Added
+- **Self-contained HTML match report.** `trialmatchai report --patient <id>`
+  renders a portable, offline `report.html` (no server, no build step, no CDN)
+  from a patient's existing results: a ranked, searchable/filterable trial list
+  with per-criterion eligibility verdicts, a collapsible chain-of-thought panel,
+  ClinicalTrials.gov links, and print/PDF styles. Emitted automatically after
+  each match, gated by `reporting.emit_html` (off for TREC sweeps).
+- **Unified multi-patient report.** `trialmatchai report --all` — and the
+  end-of-run auto-emit — writes one self-contained `index.html`: a patient front
+  page that drills into each patient's report client-side. New 13th subcommand:
+  `report`.
+- **BM25 + heuristic text-score fusion** in the LanceDB retrieval backend.
+
+### Changed
+- **Deeper TREC funnel** (1000 → 500 → 250 across first-level → rerank → CoT) via
+  a configurable `search.second_level_keep_divisor`, with concept linking enabled.
+- **`python-dotenv` is now a declared dependency**, so `.env` files (HF_TOKEN, API
+  keys, path overrides) load on a core-only `pip install trialmatchai` — it was
+  previously imported but undeclared.
+
+### Fixed
+- P0 and medium-severity bugs surfaced by the codebase audit (RRF dedup key,
+  atomic `write_text_file`, and others).
+
+### Tests
+- Coverage for production retrieval/inference paths, crash-safe resume, and
+  variant-recognizer / embedder / metrics hardening.
+
 ## [0.2.0] — 2026-06-28
 
 The **deployment-readiness** release: TrialMatchAI becomes one installable,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trialmatchai"
-version = "0.2.0"
+version = "0.3.0"
 description = "AI-driven patient-to-clinical-trial matching: hybrid retrieval + LLM eligibility reasoning."
 readme = "README.md"
 requires-python = ">=3.11,<3.12"
@@ -35,6 +35,7 @@ dependencies = [
   "numpy>=2.0,<3",
   "pandas==2.2.3",
   "python-dateutil==2.9.0.post0",
+  "python-dotenv>=1.0,<2",
   "requests==2.34.2",
   "tenacity==9.0.0",
   "tqdm==4.67.1",
@@ -77,7 +78,7 @@ finetune = [
 [project.scripts]
 # Single entry point. Every capability is a subcommand: `trialmatchai <cmd>`
 # (pipeline, healthcheck, bootstrap-data, index, build-concepts, update-registry,
-# import-patient, build, run, e2e, trec, finetune).
+# import-patient, build, run, e2e, trec, report, finetune).
 trialmatchai = "trialmatchai.cli.main:main"
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -3082,7 +3082,7 @@ wheels = [
 
 [[package]]
 name = "trialmatchai"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "lancedb", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
@@ -3092,6 +3092,7 @@ dependencies = [
     { name = "pyarrow", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "pydantic", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "python-dateutil", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "python-dotenv", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "requests", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "tenacity", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
@@ -3158,6 +3159,7 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=24.0.0,<25" },
     { name = "pydantic", specifier = ">=2.12.0,<3" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
+    { name = "python-dotenv", specifier = ">=1.0,<2" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "requests", specifier = "==2.34.2" },
     { name = "safetensors", marker = "extra == 'llm'", specifier = ">=0.6.2,<0.7" },


### PR DESCRIPTION
Bump 0.2.0 -> 0.3.0 to release 8 PRs of unreleased work on top of the published 0.2.0 (which cannot be re-uploaded to PyPI): the self-contained HTML match report (single + unified), deeper TREC funnel, BM25 text fusion, P0/medium bug fixes, and test hardening.

- pyproject: version 0.3.0; declare python-dotenv (>=1.0,<2) as a core dependency — it is imported on the core path (config_loader) but was undeclared, so .env files silently did not load on a core-only install; add 'report' to the subcommand comment (13 subcommands).
- CHANGELOG: 0.3.0 entry.

Verified: uv build + twine check --strict pass; the wheel ships the report template + logo and all package data; METADATA Requires-Dist includes python-dotenv; report tests pass.