### PR TITLE
fix: use probability scores for MLX reranking

### DIFF
--- a/docs/bootstrap-data-directory-normalization.md
+++ b/docs/bootstrap-data-directory-normalization.md
@@ -1,0 +1,92 @@
+# Bootstrap data directory normalization
+
+## Issues
+
+The published TrialMatchAI data archive `processed_trials.tar.gz` currently
+contains a top-level directory named `processed_docs/`. TrialMatchAI v0.7.0's
+bootstrap code and downstream commands expect the canonical directory
+`data/processed_trials/`.
+
+Without normalization, `bootstrap-data` extracts the trial files successfully
+but fails while writing its completion marker:
+
+```text
+FileNotFoundError: .../data/processed_trials/.bootstrap_complete
+```
+
+This is a packaging/path mismatch, not a corrupted trial corpus.
+
+The criteria ZIP archives also currently contain a redundant top-level
+`processed_criteria/` directory. Extracting them into `data/processed_criteria/`
+would otherwise produce `data/processed_criteria/processed_criteria/`, while
+the indexer expects trial-ID directories directly below `data/processed_criteria/`.
+
+## Fix
+
+`src/trialmatchai/cli/bootstrap_data.py` now normalizes the archive layout at
+the extraction boundary:
+
+```text
+data/processed_docs/  ->  data/processed_trials/
+data/processed_criteria/processed_criteria/  ->  data/processed_criteria/
+```
+
+The rest of the pipeline therefore keeps one stable path. If an archive
+contains the canonical directory already, it is left unchanged. If both names
+exist, bootstrap fails closed instead of merging ambiguous corpora. If neither
+exists, bootstrap reports an invalid archive layout.
+
+## Verification
+
+The regression tests are in `tests/test_bootstrap_data.py` and cover both
+published archive layouts. Verification performed locally:
+
+```text
+7 bootstrap-data tests passed
+The full suite passed before the criteria-layout fix; rerun it after applying
+the fix before committing.
+```
+
+## Reproduction and recovery
+
+From the TrialMatchAI checkout, run:
+
+```bash
+uv run trialmatchai bootstrap-data
+```
+
+The command should finish using the already downloaded archives, normalize the
+directory, and remove temporary archives after successful extraction. Confirm
+the result with:
+
+```bash
+find data/processed_trials -maxdepth 1 -type f | head
+find data/processed_criteria -maxdepth 2 -type f | head
+```
+
+## Future review
+
+When the upstream Zenodo archive is refreshed, inspect its top-level members
+before changing this normalization. If the upstream archive adopts the
+canonical paths, the compatibility paths can remain harmlessly in place or be
+removed in a separately reviewed cleanup. Do not silently merge conflicting
+directories.
+
+## Large-corpus indexing note
+
+The prepared corpus contains more than two million criteria JSON files. The
+indexer previously materialized every criteria record in one Python list before
+writing LanceDB, which could leave only the trial table on a 24 GB Mac if the
+process ran out of memory. Criteria indexing now uses bounded 8,192-record
+batches and creates the FTS/vector indexes only after the final batch.
+
+If a run stops after reporting the trial count, check for both tables before
+retrying:
+
+```bash
+uv run trialmatchai healthcheck --require-tables
+```
+
+The retry is safe: the trial table is recreated and criteria batches are
+written with bounded memory. Do not use `--reindex` unless an intentional full
+rebuild is needed.

--- a/docs/codex-handoff.md
+++ b/docs/codex-handoff.md
@@ -1,0 +1,261 @@
+# Codex Handoff: TAIM and TrialMatchAI
+
+## Project and goal
+
+- Main repository: /Users/mehulmittal/TAIM
+- TrialMatchAI checkout: /Users/mehulmittal/TAIM/external/trialmatchai-current
+- TrialMatchAI checkout: v0.7.0, detached at commit 071a76e.
+- Owner/collaborator: Hannes Ill.
+- Machine: Apple MacBook Pro with M5 Pro, 24 GB RAM.
+- Python: CPython 3.11.15 installed and run through uv.
+- No Docker or NVIDIA CUDA is available.
+- Goal: adapt TrialMatchAI to the TAIM benchmark contract, preserve reproducibility, and evaluate a modern local model stack.
+- Do not inspect or use protected TREC 2022/2023 topics or judgments.
+
+## What TrialMatchAI does
+
+TrialMatchAI matches a patient description to clinical trials:
+
+1. Prepare trial and eligibility-criterion records.
+2. Embed trial and criterion text.
+3. Store vectors in LanceDB.
+4. Embed the patient query.
+5. Retrieve candidate trials with hybrid search.
+6. Rerank candidates with a language model.
+7. Check eligibility with a reasoning model.
+8. Produce ranked results and reports.
+
+The end-to-end order is: index -> ingest -> expand -> match.
+
+Ranking scores are internal ranking values, not probabilities or medical recommendations.
+
+## Completed setup
+
+The following worked:
+
+    uv python install 3.11
+    uv lock --check
+    uv sync --group dev
+    uv run pytest
+
+The full test suite passed with 414 tests after the MLX work.
+
+Data is present:
+
+- data/processed_trials: 109,281 trial JSON files.
+- data/processed_criteria: approximately 2.1 million criterion JSON records.
+- Criteria are organized by NCT identifier.
+- Records include text and precomputed vector fields.
+
+The original LanceDB index was built and verified with:
+
+    uv run trialmatchai index \
+      --processed-trials-folder data/processed_trials \
+      --processed-criteria-folder data/processed_criteria
+
+    uv run trialmatchai healthcheck --require-tables
+
+A directory-marker/download layout problem was fixed and documented in docs/bootstrap-data-directory-normalization.md.
+
+## BGE-M3 status
+
+The embedding model is BAAI/bge-m3.
+
+Previously, the prepared trial and criterion files contained precomputed BGE-M3 vectors. New patient/query vectors were computed at runtime. Logs showed:
+
+    Loading embedder model BAAI/bge-m3 on device cpu
+
+Those corpus vectors came from the older text/Snapshot representation. Since Snapshot v2 changes canonical text and structured inputs, the corpus vectors should be recomputed for v2.
+
+The current embedder device logic recognizes CUDA or CPU, not Apple MPS. Setting use_gpu=true does not automatically use the M5 GPU. MPS support would require a deliberate code change and testing.
+
+### Important re-embedding memory fix
+
+An initial CPU re-embedding run was stopped after about 1.5 hours because it consumed almost all physical memory and swap without writing an index. The cause was a materialization bug in `src/trialmatchai/orchestration.py`: when `search_backend.reembed_index` was true, the code converted the entire criteria generator into one list before embedding.
+
+The re-embedding path now streams criteria in bounded batches of 8,192 records. Trial records and the first criteria batch are embedded, then each criteria batch is written to LanceDB incrementally. Only the final batch creates the vector indexes. The full criteria corpus is never held in memory at once.
+
+The process was stopped safely before it produced a partial replacement index. A regression test verifies that 8,193 criteria are handled as batches of 8,192 and 1. The external TrialMatchAI suite passes after the fix.
+
+The follow-up CPU run was later stopped after confirming that it was progressing but would take multiple days. Its empty `data/search_bge_m3_cpu_v2` directory and temporary config were removed. The original `data/search` index and processed data were left untouched. Hannes will provide embeddings generated on GCP instead.
+
+## Current CPU recomputation
+
+A separate CPU-only index is being built with:
+
+    jq '
+      .embedder.use_gpu = false
+      | .search_backend.reembed_index = true
+      | .search_backend.db_path = "data/search_bge_m3_cpu_v2"
+    ' src/trialmatchai/config/config.json > /tmp/trialmatchai-cpu-reembed.json
+
+    uv run trialmatchai index \
+      --config /tmp/trialmatchai-cpu-reembed.json \
+      --reindex \
+      --processed-trials-folder data/processed_trials \
+      --processed-criteria-folder data/processed_criteria
+
+This recomputes BGE-M3 vectors for more than 2.2 million texts. It may take several hours on CPU. It writes to data/search_bge_m3_cpu_v2 and leaves data/search untouched.
+
+After completion:
+
+1. Record the total runtime.
+2. Check the final trial and criteria counts.
+3. Run a healthcheck using the new config.
+4. Run a small e2e smoke test using the new config.
+5. Keep the old index until the new one is verified.
+
+## Modern MLX model stack
+
+The original config referenced microsoft/phi-4 and google/gemma-2-2b-it.
+
+The modern local setup is:
+
+- Eligibility reasoning: mlx-community/Qwen3.5-9B-4bit
+- Retrieval reranking: mlx-community/gemma-4-e4b-it-4bit
+- Embeddings/search: BAAI/bge-m3 for now
+
+Standalone tests succeeded for Qwen3.5 and Gemma 4. MLX-VLM 0.6.8 is in the lockfile. Dependency pins were widened to support MLX-VLM:
+
+- transformers >=5.14,<6
+- safetensors >=0.8,<1
+
+MLX support was added in:
+
+- src/trialmatchai/models/llm/mlx_loader.py
+- src/trialmatchai/models/llm/mlx_reranker.py
+- src/trialmatchai/models/llm/mlx_vlm_loader.py
+- src/trialmatchai/matching/eligibility_reasoning_mlx.py
+- src/trialmatchai/matching/eligibility_reasoning_mlx_vlm.py
+- tests/test_mlx_backend.py
+- docs/mac-mlx-implementation.md
+
+The MLX-LM API required make_sampler(temperature), not the old temp argument. That compatibility issue was fixed.
+
+Qwen3.5 eligibility output initially stopped with invalid JSON at a low token limit. Using TRIALMATCHAI_MLX_MAX_NEW_TOKENS=8192 allowed a complete smoke run.
+
+## Modern smoke tests
+
+Synthetic files were used only for wiring/runtime checks, not clinical claims:
+
+- data/patients/mlx_smoke_patient.txt
+- data/patients/mlx_modern_smoke_patient.txt
+
+The modern e2e run completed retrieval, reranking, Qwen3.5 eligibility reasoning, final ranking, and report creation. One result was produced for NCT05752136.
+
+Expected smoke-test warnings:
+
+- Hugging Face unauthenticated request: rate-limit notice.
+- BGE-M3 optional file 404s: normal repository probing.
+- No annotations found: expected because entity extraction was disabled.
+- Existing outputs may be skipped unless --rematch is supplied.
+
+## Snapshot v2 contract
+
+The owner proposed TAIM Issue #8:
+https://github.com/hannesill/TAIM/issues/8
+
+The specification is appropriate and aligns with the adapter plan. Its key rules are:
+
+- Preserve structured patient and trial fields.
+- Also provide deterministic canonical text for text-only systems.
+- Preserve field-level provenance.
+- Preserve missingness and conflicts; never guess defaults.
+- Keep derived views separately named, versioned, and hashed.
+- Keep judgments/qrels outside the System request.
+- Use only frozen TREC 2021 source artifacts for the historical benchmark.
+- Keep TREC 2022/2023 protected.
+- Do not relabel v1 indexes, embeddings, or results as v2.
+- Keep TrialMatchAI prompts, ranking, filtering, and eligibility decisions outside the shared Snapshot contract.
+
+## Adapter design
+
+The intended flow is:
+
+    TAIM Snapshot v2
+      -> adapter reads permitted structured fields
+      -> deterministic renderer creates TrialMatchAI prompts
+      -> TrialMatchAI retrieval/reranking/eligibility
+      -> adapter emits standard TAIM Candidate records
+
+The adapter must not use evaluation judgments or hidden evaluator information. It should preserve retrieval, reranking, eligibility decisions, explanations, and raw outputs as diagnostics.
+
+The owner still needs to confirm:
+
+1. Which Snapshot capabilities the adapter may consume.
+2. The exact deterministic rendering format.
+3. Whether final post-eligibility ranking is the Primary Ranking.
+4. Which intermediate outputs must be stored as Stage Rankings/artifacts.
+
+Recommended Primary Ranking: final post-eligibility ranking. Retrieval and reranking outputs remain diagnostic.
+
+## Adapter work completed so far
+
+The TAIM repository now contains the first adapter boundary slice:
+
+- `src/taim/adapters/trialmatchai.py`
+- `src/taim/adapters/__init__.py`
+- `tests/test_trialmatchai_adapter.py`
+- `docs/trialmatchai-adapter.md`
+
+These helpers do not import or patch TrialMatchAI. They:
+
+1. Render deterministic patient input from either the v1 `patient_text` field or the v2 `canonical_text` field.
+2. Append Snapshot v2 typed patient facts in stable field order when explicitly available.
+3. Write newline-stable patient files for the upstream command.
+4. Run a pinned TrialMatchAI command as an isolated subprocess with timeout and failure handling.
+5. Parse TrialMatchAI `ranked_trials.json` output.
+6. Convert final results into TAIM `Candidate` records.
+7. Apply deterministic score-descending/trial-ID-ascending tie breaking.
+8. Keep optional first-level retrieval scores as diagnostic rankings rather than silently treating them as final output.
+
+The full TAIM suite passes with 266 tests, and Ruff checks pass. This is the adapter foundation, not yet the complete benchmark runner.
+
+## Current plan
+
+Completed:
+
+1. Understand repository, vocabulary, and pipeline.
+2. Set up uv and Python.
+3. Study CLI and file structure.
+4. Download and inspect data.
+5. Build and verify LanceDB.
+6. Add and test MLX support.
+7. Validate Qwen3.5 and Gemma 4 locally.
+8. Run modern TrialMatchAI smoke tests.
+
+In progress:
+
+9. Recompute BGE-M3 corpus embeddings on CPU for Snapshot v2 compatibility.
+10. Implement and test the adapter input/output boundary.
+
+Next:
+
+11. Verify the new CPU index.
+12. Obtain a concrete Snapshot v2 schema/sample in the working branch after PR #25 lands.
+13. Agree on permitted Snapshot capabilities.
+14. Confirm Primary Ranking semantics.
+15. Build the full topic-run orchestrator around the adapter boundary.
+16. Stage complete Snapshot topics/trials for the pinned TrialMatchAI checkout.
+17. Record Snapshot identity, model revisions, embedding identity, timings, manifests, raw-output hashes, and artifacts.
+18. Run the original setup on a small fixed calibration subset if required.
+19. Run the modern model configuration on the agreed benchmark input.
+
+## Safety and reproducibility rules
+
+- Do not use protected TREC 2022/2023 data.
+- Do not call synthetic smoke-test results clinical performance.
+- Do not treat ranking scores as probabilities.
+- Do not enrich frozen TREC 2021 data from live ClinicalTrials.gov.
+- Do not silently reuse old vectors for Snapshot v2.
+- Do not replace structured source fields with model-inferred facts.
+- Do not change ranking or eligibility semantics while building the shared adapter unless explicitly agreed.
+
+Useful checks:
+
+    uv run pytest
+    uv run trialmatchai healthcheck --require-tables
+    uv run trialmatchai build --status
+    git status --short --branch
+
+When resuming, first check whether the CPU embedding command is still running or has completed. Inspect its final output before starting another expensive job.

--- a/docs/mac-mlx-implementation.md
+++ b/docs/mac-mlx-implementation.md
@@ -1,0 +1,459 @@
+# TrialMatchAI on Apple Silicon: MLX Implementation Notes
+
+This document records the Apple-Silicon work completed for the TrialMatchAI v0.7.0
+checkout. It is written as both a review record and a beginner-friendly explanation.
+
+## 1. The original problem
+
+TrialMatchAI's original language-model path is designed around vLLM. vLLM is a fast
+model-serving engine that is mainly used with NVIDIA CUDA GPUs and Linux. The M5
+MacBook Pro has an Apple GPU, not an NVIDIA CUDA GPU, so the original vLLM path is
+not the natural local runtime for this machine.
+
+The goal was therefore:
+
+1. Keep the original vLLM and Phi-4 configuration intact for reproducibility.
+2. Add a separate MLX path for local Apple-Silicon experiments.
+3. Use a smaller modern model locally before attempting a full pipeline run.
+4. Keep the change optional, so users who do not need MLX do not install it.
+
+## 2. Simple vocabulary
+
+### Runtime backend
+
+A runtime backend is the engine that loads and runs a language model.
+
+Analogy: the model is a car, while vLLM, Transformers, and MLX are different roads
+and driving systems. The same car cannot use every road in exactly the same way.
+
+### vLLM
+
+vLLM is a high-throughput model engine. It is excellent for NVIDIA GPU servers and
+supports features such as batching and token-level scores used by the existing
+TrialMatchAI implementation.
+
+### Transformers
+
+Transformers is the general Hugging Face model interface. It can run models directly,
+including CPU smoke tests, but is usually slower for large-scale serving.
+
+### MLX
+
+MLX is Apple's machine-learning framework for Apple Silicon. MLX-LM adds convenient
+loading and text generation for language models on the Mac GPU.
+
+### Quantized model
+
+Quantization stores model numbers using fewer bits. This makes the model smaller and
+faster, with a possible quality trade-off.
+
+Analogy: instead of storing every measurement with ten decimal places, we store only
+the precision needed for the task.
+
+### Smoke test
+
+A smoke test is a tiny test that answers: "Does the basic path start and produce an
+answer?" It is not a scientific benchmark and does not prove final quality.
+
+## 3. Why Qwen3-8B-4bit was selected first
+
+The first local candidate is:
+
+```text
+mlx-community/Qwen3-8B-4bit
+```
+
+Reasons:
+
+- It has an MLX-ready model package.
+- It is text-only, so it matches TrialMatchAI's language workload.
+- The 4-bit package is approximately 4.6 GB, which is practical on a 24 GB Mac.
+- It is much smaller than Phi-4 14B, leaving memory for the operating system,
+  embeddings, LanceDB, and application code.
+- Its chat template can be used through the standard MLX-LM API.
+
+This is an engineering starting point, not a claim that Qwen3 is automatically better
+than every Gemma or Phi model. Quality must be measured later on the agreed benchmark.
+
+## 4. What was changed
+
+### Optional dependency
+
+In `pyproject.toml`, an optional dependency group was added:
+
+```toml
+mlx = [
+  "mlx-lm>=0.26; sys_platform == 'darwin'",
+]
+```
+
+The Darwin condition means this dependency is selected on macOS. It is not forced on
+Linux installations that use vLLM.
+
+Install it with:
+
+```bash
+uv sync --extra mlx
+```
+
+This installed MLX-LM, MLX, and the Apple Metal support package in the local virtual
+environment. `uv.lock` records the exact resolved versions for reproducibility.
+
+### MLX model loader
+
+File: `src/trialmatchai/models/llm/mlx_loader.py`
+
+This wrapper does four jobs:
+
+1. Imports MLX-LM only when the MLX backend is actually used.
+2. Loads a local directory or Hugging Face model identifier.
+3. Applies the model's chat template when one exists.
+4. Calls MLX-LM generation with a maximum token count and temperature.
+
+Lazy importing is important. A normal TrialMatchAI installation should still be able
+to use the original backends without requiring MLX.
+
+### MLX eligibility reasoning
+
+File: `src/trialmatchai/matching/eligibility_reasoning_mlx.py`
+
+This adds `BatchTrialProcessorMLX`, which follows the existing
+`BaseTrialProcessor` contract:
+
+1. Load a trial's eligibility criteria.
+2. Combine the criteria with the patient narrative.
+3. Build the existing TrialMatchAI prompt.
+4. Send the prompt to MLX-LM.
+5. Save the raw text and parsed JSON result in the same output structure.
+
+The first version intentionally processes items sequentially. This is slower than a
+server batch, but it keeps unified Apple memory bounded and makes debugging easier.
+
+Important correction: `BaseTrialProcessor` already applies the tokenizer chat
+template. The MLX processor now sends that formatted prompt directly. Applying the
+template a second time would incorrectly put one formatted conversation inside another
+user message.
+
+### MLX reranker
+
+File: `src/trialmatchai/models/llm/mlx_reranker.py`
+
+The existing reranker asks a language model whether a patient-trial pair is a match.
+The MLX implementation generates a short answer and maps it as follows:
+
+```text
+Yes       -> 1.0
+No        -> 0.0
+Unclear   -> 0.5
+```
+
+This is a generated-label score. It is not the same as a calibrated next-token
+probability from vLLM. Therefore, when we benchmark this path, the provenance must
+record that the MLX reranker uses generated labels.
+
+### Query expansion
+
+File: `src/trialmatchai/matching/query_expansion.py`
+
+The optional query-expansion component can now use MLX as well. It remains disabled by
+default, so adding MLX support does not silently change the normal pipeline.
+
+### Configuration and preflight
+
+Files:
+
+- `src/trialmatchai/config/settings.py`
+- `src/trialmatchai/main.py`
+- `src/trialmatchai/services/preflight.py`
+
+The accepted backend names now include `mlx` for retrieval reasoning, reranking, and
+query expansion. When the configured backend is MLX, the program checks that `mlx_lm`
+is installed and gives this actionable message if it is missing:
+
+```text
+MLX backend requires mlx-lm (`uv sync --extra mlx`).
+```
+
+The default configuration still points to Phi-4, Gemma 2, and vLLM. A separate Mac
+configuration should be created for experiments rather than overwriting the canonical
+configuration.
+
+## 5. What was not changed
+
+- The original Phi-4 model configuration was not replaced.
+- The original vLLM backend was not removed.
+- The LanceDB data and index format was not changed.
+- No claim was made that the MLX model reproduces vLLM scores exactly.
+- No full benchmark result has been produced yet.
+
+This separation lets us compare an original calibration run with a modern local-model
+run later.
+
+## 6. Verification performed
+
+The following checks passed after the implementation:
+
+```text
+414 tests passed
+ruff lint passed for the new MLX files
+```
+
+A focused unit test also verified that:
+
+- the model revision is passed to MLX-LM's `load()` function;
+- the prompt is passed once to generation;
+- `max_tokens`, temperature, and quiet output are forwarded correctly.
+
+The current execution environment cannot access a physical Metal device, so actual
+GPU inference must be run on the user's M5 Mac. The code and API contract were checked
+against the installed MLX-LM package.
+
+## 7. First real M5 smoke test
+
+Run this from the TrialMatchAI checkout:
+
+```bash
+cd /Users/mehulmittal/TAIM/external/trialmatchai-current
+
+uv sync --extra mlx
+
+uv run mlx_lm.generate \
+  --model mlx-community/Qwen3-8B-4bit \
+  --prompt "Reply with exactly: MLX works" \
+  --max-tokens 16 \
+  --temp 0
+```
+
+The first run downloads the model. Success means the command returns the requested
+answer without a Metal, model-loading, or tokenizer error.
+
+## 8. Selecting MLX without changing the original config
+
+The repository's standard configuration intentionally still names the original
+backends. For a Mac experiment, backend and model values can be supplied through
+environment variables instead of editing `config.json`:
+
+```bash
+export TRIALMATCHAI_RAG_BACKEND=mlx
+export TRIALMATCHAI_RERANKER_BACKEND=mlx
+export TRIALMATCHAI_MODEL_BASE_MODEL=mlx-community/Qwen3-8B-4bit
+export TRIALMATCHAI_MODEL_RERANKER_MODEL_PATH=mlx-community/Qwen3-8B-4bit
+export TRIALMATCHAI_EMBEDDER_USE_GPU=false
+export TRIALMATCHAI_ENTITY_BACKEND=disabled
+export TRIALMATCHAI_CONCEPT_LINKER_ENABLED=false
+```
+
+The first two variables select the MLX engine. The next two choose the Qwen3 model.
+The embedder flag prevents a CUDA check. Entity extraction and concept linking are
+disabled for the first smoke run because they are optional and would introduce extra
+models before the core path is proven.
+
+The configuration can be checked with:
+
+```bash
+uv run trialmatchai healthcheck --require-tables --models
+```
+
+The healthcheck may warn that it cannot contact Hugging Face when the model is already
+cached or the network is unavailable. That warning is separate from the LanceDB and
+MLX dependency checks.
+
+The full matching path also needs PyTorch because TrialMatchAI's BGE-M3 embedder uses
+PyTorch to turn the patient narrative into a search vector. On this Mac it can run on
+CPU; it does not require CUDA:
+
+```bash
+uv sync --extra llm
+```
+
+## 9. What this smoke test does not prove
+
+It does not prove that TrialMatchAI's clinical matching quality is good. It only proves
+that:
+
+- the model can be downloaded;
+- MLX can use the Mac GPU;
+- the tokenizer and generation API work;
+- a small prompt can complete.
+
+The next test is an isolated TrialMatchAI eligibility run on one patient and a very
+small fixed trial list. Only after that should we run a larger comparison.
+
+## 10. Synthetic patient smoke test
+
+The repository did not include a patient profile. A small fictional input was added at:
+
+```text
+data/patients/mlx_smoke_patient.txt
+```
+
+This file is ignored by Git because the repository ignores the whole `data/` directory.
+It is not real clinical data and must only be used to test wiring. It describes a
+fictional 55-year-old woman with rectal adenocarcinoma.
+
+The first end-to-end run uses a deliberately small retrieval budget. This prevents a
+beginner smoke test from invoking the model for hundreds of trials:
+
+```bash
+export TRIALMATCHAI_RAG_BACKEND=mlx
+export TRIALMATCHAI_RERANKER_BACKEND=mlx
+export TRIALMATCHAI_MODEL_BASE_MODEL=mlx-community/Qwen3-8B-4bit
+export TRIALMATCHAI_MODEL_RERANKER_MODEL_PATH=mlx-community/Qwen3-8B-4bit
+export TRIALMATCHAI_EMBEDDER_USE_GPU=false
+export TRIALMATCHAI_ENTITY_BACKEND=disabled
+export TRIALMATCHAI_CONCEPT_LINKER_ENABLED=false
+export TRIALMATCHAI_SEARCH_MAX_TRIALS_FIRST_LEVEL=5
+export TRIALMATCHAI_FIRST_LEVEL_MAX_TRIALS=5
+export TRIALMATCHAI_FIRST_LEVEL_PER_CHANNEL_SIZE=5
+export TRIALMATCHAI_SEARCH_CANDIDATE_LIMIT=20
+export TRIALMATCHAI_RAG_NO_THINK=true
+export TRIALMATCHAI_MLX_MAX_NEW_TOKENS=2048
+
+uv run trialmatchai e2e \
+  --input data/patients/mlx_smoke_patient.txt \
+  --format text \
+  --processed-trials-folder data/processed_trials \
+  --processed-criteria-folder data/processed_criteria \
+  --no-entities \
+  --reingest \
+  --rematch
+```
+
+What the switches mean:
+
+- `RAG_BACKEND` selects MLX for eligibility reasoning.
+- `RERANKER_BACKEND` selects MLX for the reranking step.
+- The two model variables select Qwen3 for both temporary smoke-test roles.
+- `EMBEDDER_USE_GPU=false` avoids a CUDA check for the BGE-M3 search embedder.
+- `ENTITY_BACKEND=disabled` and `CONCEPT_LINKER_ENABLED=false` remove optional stages
+  from this first wiring test.
+- The search limits reduce the candidate set to approximately five trials.
+- `RAG_NO_THINK=true` tells Qwen3 not to spend the output budget on a private thinking
+  preamble before the required JSON.
+- `MLX_MAX_NEW_TOKENS=2048` gives the structured JSON response enough room to finish.
+- `--reingest` imports the input again, and `--rematch` forces a fresh match.
+
+This run is a wiring test, not a medical recommendation and not a benchmark result.
+Inspect the generated files under the configured `results/` directory, especially the
+ranked trial list, per-trial eligibility JSON, and raw model text.
+
+### MLX-LM sampling compatibility note
+
+MLX-LM's command-line interface accepts `--temp`, but its Python generation function
+passes sampling through a sampler callback. The adapter therefore uses
+`mlx_lm.sample_utils.make_sampler(temperature)` and passes the resulting sampler to
+generation. Passing `temp` directly caused this runtime error with MLX-LM 0.31.3:
+
+```text
+TypeError: generate_step() got an unexpected keyword argument 'temp'
+```
+
+The fix is covered by `tests/test_mlx_backend.py` and the complete test suite passes.
+
+### Structured-output note
+
+The first end-to-end run completed retrieval and ranking, but the eligibility response
+for one trial was cut off inside `<think>` after the default 256-token limit. TrialMatchAI
+correctly saved an `invalid_json_response` artifact and continued, but that is not a
+usable eligibility explanation. Disabling thinking and increasing the MLX output budget
+to 2048 tokens addresses this smoke-test failure. This setting is specific to the local
+Qwen3 experiment and should be recorded in any later benchmark manifest.
+
+## 11. Planned next steps
+
+1. Run the Qwen3 MLX smoke test on the physical M5 Mac.
+2. Run the Qwen3.5 plus Gemma4 smoke test using the integrated `mlx_vlm` and `mlx`
+   backends.
+3. Run one patient against a tiny, fixed trial subset.
+4. Inspect the saved JSON and raw text outputs.
+5. Compare the original setup and modern MLX setup on a reduced calibration dataset.
+6. Build the TAIM adapter using the shared ranking and provenance contracts.
+7. Run the agreed benchmark using graded nDCG@10 as the primary metric.
+
+## References
+
+- [MLX-LM official repository](https://github.com/ml-explore/mlx-lm)
+- [Qwen3-8B MLX 4-bit model card](https://huggingface.co/mlx-community/Qwen3-8B-4bit)
+- [Gemma 4 MLX 12B model card](https://huggingface.co/mlx-community/gemma-4-12B-4bit)
+
+## Qwen3.5 investigation note
+
+Qwen3.5-9B-4bit loaded on the M5 and used about 6.7 GB peak memory, but the short
+text-only smoke prompt produced corrupted-looking output. The model card identifies it
+as a multimodal checkpoint converted with an older MLX-VLM release. Current MLX-VLM
+release notes mention Qwen3.5 fixes and text-only wrapper fixes, so this may be a runtime
+compatibility problem rather than a hardware problem.
+
+The newest MLX-VLM release requires a newer Transformers version than TrialMatchAI's
+entity/LLM extras currently pin. We therefore keep the project lock compatible and test
+the newer MLX-VLM in an isolated environment:
+
+```bash
+uv run --isolated --with "mlx-vlm==0.6.6" \
+  python -m mlx_vlm.generate \
+  --model mlx-community/Qwen3.5-9B-4bit \
+  --prompt "Reply with exactly: Qwen 3.5 works" \
+  --max-tokens 32 \
+  --temperature 0.0 \
+  --thinking-mode disabled
+```
+
+Only if this produces clean text should Qwen3.5 be integrated into the TrialMatchAI
+adapter. Otherwise, Qwen3 remains the proven local reasoning fallback.
+
+## Modern model-stack smoke run
+
+After installing the resolved optional dependencies:
+
+```bash
+uv sync --extra llm --extra mlx --extra mlx-vlm
+```
+
+select the modern model pair with environment variables:
+
+```bash
+export TRIALMATCHAI_RAG_BACKEND=mlx_vlm
+export TRIALMATCHAI_RERANKER_BACKEND=mlx
+export TRIALMATCHAI_MODEL_BASE_MODEL=mlx-community/Qwen3.5-9B-4bit
+export TRIALMATCHAI_MODEL_RERANKER_MODEL_PATH=mlx-community/gemma-4-e4b-it-4bit
+export TRIALMATCHAI_EMBEDDER_USE_GPU=false
+export TRIALMATCHAI_ENTITY_BACKEND=disabled
+export TRIALMATCHAI_CONCEPT_LINKER_ENABLED=false
+export TRIALMATCHAI_TRIALS_JSON_FOLDER=data/processed_trials
+export TRIALMATCHAI_SEARCH_MAX_TRIALS_FIRST_LEVEL=5
+export TRIALMATCHAI_FIRST_LEVEL_MAX_TRIALS=5
+export TRIALMATCHAI_FIRST_LEVEL_PER_CHANNEL_SIZE=5
+export TRIALMATCHAI_SEARCH_CANDIDATE_LIMIT=20
+export TRIALMATCHAI_RAG_NO_THINK=true
+export TRIALMATCHAI_MLX_MAX_NEW_TOKENS=2048
+```
+
+Then run the same synthetic patient:
+
+```bash
+uv run trialmatchai e2e \
+  --input data/patients/mlx_smoke_patient.txt \
+  --format text \
+  --processed-trials-folder data/processed_trials \
+  --processed-criteria-folder data/processed_criteria \
+  --no-entities \
+  --reingest \
+  --rematch
+```
+
+This run tests the full modern pair: Qwen3.5 performs the long eligibility response,
+while Gemma4 performs criterion reranking. It is still a wiring test, not a clinical
+quality result.
+
+The first successful modern run produced:
+
+```text
+Qwen3.5 MLX-VLM eligibility output: valid JSON
+Gemma4 MLX reranker: loaded and completed
+TrialMatchAI pipeline: complete
+```
+
+For the synthetic modern patient, the selected trial was `NCT05752136` and the model
+returned `Likely Ineligible (leaning toward exclusion)`. The result contained 11
+inclusion evaluations and 16 exclusion evaluations. The ranking score is an internal
+pipeline score, not a probability that the patient is eligible.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,22 +52,28 @@ gpu = [
 ]
 llm = [
   "torch==2.11.0",
-  "transformers==5.6.2",
+  "transformers>=5.14.0,<6",
   "accelerate==1.8.1",
   "tokenizers==0.22.1",
-  "safetensors>=0.6.2,<0.7",
+  "safetensors>=0.8.0,<1",
   "sentencepiece==0.2.1",
   "peft==0.15.2",
   "einops==0.8.0",
 ]
 entity = [
   "torch==2.11.0",
-  "transformers==5.6.2",
+  "transformers>=5.14.0,<6",
   "gliner2>=1.3.1,<2",
+]
+mlx = [
+  "mlx-lm>=0.26; sys_platform == 'darwin'",
+]
+mlx-vlm = [
+  "mlx-vlm>=0.6; sys_platform == 'darwin'",
 ]
 finetune = [
   "torch==2.11.0",
-  "transformers==5.6.2",
+  "transformers>=5.14.0,<6",
   "accelerate==1.8.1",
   "peft==0.15.2",
   "datasets>=3.0,<5",

--- a/src/trialmatchai/cli/bootstrap_data.py
+++ b/src/trialmatchai/cli/bootstrap_data.py
@@ -112,8 +112,9 @@ def bootstrap_data(
     data_dir.mkdir(parents=True, exist_ok=True)
 
     criteria_dir = data_dir / "processed_criteria"
+    criteria_dir.mkdir(parents=True, exist_ok=True)
+    _normalize_processed_criteria_directory(criteria_dir)
     if force or not _extract_complete(criteria_dir):
-        criteria_dir.mkdir(parents=True, exist_ok=True)
         for index in range(criteria_chunks):
             chunk_name = f"{CHUNK_PREFIX}_{index}.zip"
             chunk_path = data_dir / chunk_name
@@ -126,6 +127,7 @@ def bootstrap_data(
                 os.getenv(f"TRIALMATCHAI_CRITERIA_PART_{index}_SHA256"),
             )
             _safe_extract_zip(chunk_path, criteria_dir)
+        _normalize_processed_criteria_directory(criteria_dir)
         _mark_extract_complete(criteria_dir)
 
     processed_trials_dir = data_dir / "processed_trials"
@@ -136,6 +138,7 @@ def bootstrap_data(
             processed_archive, os.getenv("TRIALMATCHAI_PROCESSED_TRIALS_SHA256")
         )
         _safe_extract_tar_gz(processed_archive, data_dir)
+        _normalize_processed_trials_directory(data_dir)
         _mark_extract_complete(processed_trials_dir)
 
     if with_models:
@@ -216,6 +219,49 @@ def _safe_extract_zip(archive: Path, target: Path) -> None:
             if stat.S_ISLNK(mode):
                 raise ValueError(f"Archive contains an unsafe member: {member.filename}")
         zip_file.extractall(target)
+
+
+def _normalize_processed_trials_directory(data_dir: Path) -> None:
+    """Normalize the published archive's legacy trial directory name.
+
+    Some published TrialMatchAI archives use ``processed_docs`` as their
+    top-level directory, while the CLI contract and all downstream stages use
+    ``processed_trials``.  Rename the legacy directory once at the extraction
+    boundary so the rest of the pipeline has one stable path.
+    """
+
+    canonical = data_dir / "processed_trials"
+    legacy = data_dir / "processed_docs"
+    if canonical.exists():
+        if legacy.exists():
+            raise RuntimeError(
+                "trial archive contains both processed_trials and processed_docs; "
+                "refusing to merge ambiguous corpora"
+            )
+        return
+    if legacy.exists():
+        legacy.replace(canonical)
+        return
+    raise FileNotFoundError(
+        "trial archive did not create processed_trials or processed_docs"
+    )
+
+
+def _normalize_processed_criteria_directory(criteria_dir: Path) -> None:
+    """Flatten an archive that adds a redundant ``processed_criteria`` root."""
+
+    nested = criteria_dir / "processed_criteria"
+    if not nested.is_dir():
+        return
+    for child in nested.iterdir():
+        destination = criteria_dir / child.name
+        if destination.exists():
+            raise RuntimeError(
+                "criteria archive contains both nested and top-level entries; "
+                "refusing to merge ambiguous corpora"
+            )
+        child.replace(destination)
+    nested.rmdir()
 
 
 def _validated_target_path(target: Path, member_name: str) -> Path:

--- a/src/trialmatchai/config/settings.py
+++ b/src/trialmatchai/config/settings.py
@@ -221,7 +221,7 @@ class ConstraintSettings(BaseModel):
 
 class RagSettings(BaseModel):
     enabled: bool = True
-    backend: Literal["vllm", "transformers"] = "vllm"
+    backend: Literal["vllm", "transformers", "mlx", "mlx_vlm"] = "vllm"
     batch_size: int = Field(4, ge=1)
     max_trials_rag: int = Field(20, ge=1)
     # Suppress chain-of-thought <think> in the eligibility stage for reasoning models (Qwen3):
@@ -266,7 +266,7 @@ class CotSettings(BaseModel):
 
 class LLMRerankerSettings(BaseModel):
     enabled: bool = True
-    backend: Literal["vllm", "transformers"] = "vllm"
+    backend: Literal["vllm", "transformers", "mlx"] = "vllm"
     batch_size: int = Field(20, ge=1)
     # vLLM reranker engine's share of GPU memory; lower it (with vllm.gpu_memory_utilization)
     # to fit both engines on a smaller card (e.g. 48GB A40/L40).
@@ -279,7 +279,7 @@ class QueryExpansionSettings(BaseModel):
     """Runtime CoT query expansion (legacy keywords.json behaviour)."""
 
     enabled: bool = False
-    backend: Literal["vllm", "transformers"] | None = None
+    backend: Literal["vllm", "transformers", "mlx"] | None = None
     model: str | None = None
     adapter: str | None = None
     max_new_tokens: int = Field(2048, ge=1)
@@ -295,6 +295,14 @@ class ReportingSettings(BaseModel):
     """HTML match-report generation."""
 
     emit_html: bool = True
+
+
+class MlxSettings(BaseModel):
+    """Optional Apple-Silicon generation settings."""
+
+    batch_size: int = Field(1, ge=1)
+    max_new_tokens: int = Field(512, ge=1)
+    temperature: float = Field(0.0, ge=0.0)
 
 
 class TrialMatchSettings(BaseModel):
@@ -321,6 +329,7 @@ class TrialMatchSettings(BaseModel):
     use_cot_reasoning: bool = True
     rag: RagSettings
     vllm: VllmSettings
+    mlx: MlxSettings = Field(default_factory=MlxSettings)
 
     def to_dict(self) -> Dict[str, Any]:
         return self.model_dump(by_alias=True)
@@ -342,6 +351,8 @@ def apply_env_overrides(raw: Dict[str, Any]) -> Dict[str, Any]:
         "TRIALMATCHAI_SEARCH_TRIALS_TABLE": ("search_backend", "trials_table"),
         "TRIALMATCHAI_SEARCH_CRITERIA_TABLE": ("search_backend", "criteria_table"),
         "TRIALMATCHAI_SEARCH_MODE": ("search", "mode"),
+        "TRIALMATCHAI_RAG_BACKEND": ("rag", "backend"),
+        "TRIALMATCHAI_RERANKER_BACKEND": ("LLM_reranker", "backend"),
         "TRIALMATCHAI_EMBEDDER_MODEL_NAME": ("embedder", "model_name"),
         "TRIALMATCHAI_EMBEDDER_REVISION": ("embedder", "revision"),
         "TRIALMATCHAI_MODEL_BASE_MODEL": ("model", "base_model"),
@@ -427,6 +438,7 @@ def apply_env_overrides(raw: Dict[str, Any]) -> Dict[str, Any]:
             "first_level",
             "write_reports",
         ),
+        "TRIALMATCHAI_RAG_NO_THINK": ("rag", "no_think"),
     }
     for env_key, path in bool_env_map.items():
         value = os.getenv(env_key)
@@ -434,6 +446,7 @@ def apply_env_overrides(raw: Dict[str, Any]) -> Dict[str, Any]:
             _set_nested(raw, path, _parse_bool(value))
 
     int_env_map: dict[str, Tuple[str, ...]] = {
+        "TRIALMATCHAI_MLX_MAX_NEW_TOKENS": ("mlx", "max_new_tokens"),
         "TRIALMATCHAI_SEARCH_CANDIDATE_LIMIT": (
             "search_backend",
             "candidate_limit",

--- a/src/trialmatchai/config/settings.py
+++ b/src/trialmatchai/config/settings.py
@@ -480,6 +480,10 @@ def apply_env_overrides(raw: Dict[str, Any]) -> Dict[str, Any]:
             "search",
             "max_trials_second_level",
         ),
+        "TRIALMATCHAI_SEARCH_SECOND_LEVEL_KEEP_DIVISOR": (
+            "search",
+            "second_level_keep_divisor",
+        ),
         "TRIALMATCHAI_RAG_MAX_TRIALS": ("rag", "max_trials_rag"),
         "TRIALMATCHAI_VLLM_BATCH_SIZE": ("vllm", "batch_size"),
         "TRIALMATCHAI_VLLM_MAX_NEW_TOKENS": ("vllm", "max_new_tokens"),

--- a/src/trialmatchai/main.py
+++ b/src/trialmatchai/main.py
@@ -400,6 +400,35 @@ def run_rag_processing(
             length_bucket=vllm_cfg.get("length_bucket", True),
             no_think=rag_cfg.get("no_think", False),
         )
+    elif rag_backend == "mlx":
+        from trialmatchai.matching.eligibility_reasoning_mlx import BatchTrialProcessorMLX
+
+        mlx_cfg = config.get("mlx", {})
+        rag_processor = BatchTrialProcessorMLX(
+            model_path=config["model"]["base_model"],
+            batch_size=mlx_cfg.get("batch_size", 1),
+            use_cot=config.get("use_cot_reasoning", True),
+            max_new_tokens=mlx_cfg.get("max_new_tokens", 256),
+            temperature=mlx_cfg.get("temperature", 0.0),
+            revision=config["model"].get("base_model_revision"),
+            trust_remote_code=config["model"].get("trust_remote_code", False),
+            no_think=rag_cfg.get("no_think", False),
+        )
+    elif rag_backend == "mlx_vlm":
+        from trialmatchai.matching.eligibility_reasoning_mlx_vlm import (
+            BatchTrialProcessorMLXVLM,
+        )
+
+        mlx_cfg = config.get("mlx", {})
+        rag_processor = BatchTrialProcessorMLXVLM(
+            model_path=config["model"]["base_model"],
+            batch_size=mlx_cfg.get("batch_size", 1),
+            use_cot=config.get("use_cot_reasoning", True),
+            max_new_tokens=mlx_cfg.get("max_new_tokens", 2048),
+            temperature=mlx_cfg.get("temperature", 0.0),
+            revision=config["model"].get("base_model_revision"),
+            no_think=rag_cfg.get("no_think", False),
+        )
     elif rag_backend == "vllm":
         from trialmatchai.matching.eligibility_reasoning_vllm import (
             BatchTrialProcessorVLLM,
@@ -539,6 +568,16 @@ def main_pipeline(
                     model_path=config["model"]["reranker_model_path"],
                     device=str(config["global"]["device"]),
                     batch_size=config.get("LLM_reranker", {}).get("batch_size", 8),
+                    revision=config["model"].get("reranker_model_revision"),
+                    trust_remote_code=config["model"].get("trust_remote_code", False),
+                )
+            elif _reranker_backend(config) == "mlx":
+                from trialmatchai.models.llm.mlx_reranker import MLXReranker
+
+                reranker_cfg = config.get("LLM_reranker", {})
+                llm_reranker = MLXReranker(
+                    model_path=config["model"]["reranker_model_path"],
+                    batch_size=reranker_cfg.get("batch_size", 1),
                     revision=config["model"].get("reranker_model_revision"),
                     trust_remote_code=config["model"].get("trust_remote_code", False),
                 )

--- a/src/trialmatchai/main.py
+++ b/src/trialmatchai/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple
@@ -42,6 +43,31 @@ if TYPE_CHECKING:
     from trialmatchai.models.embedding.text_embedder import TextEmbedder
 
 logger = setup_logging(__name__)
+
+
+def _release_single_patient_mlx_reranker(gemma_retriever, llm_reranker, config):
+    """Release Gemma before loading the eligibility model in adapter-style runs.
+
+    The TAIM adapter launches one TrialMatchAI process per patient. In that mode the
+    reranker is no longer needed after second-level retrieval, so releasing it avoids
+    keeping both MLX language models resident in unified memory. Multi-patient runs
+    retain the reranker so later patients preserve their normal behavior.
+    """
+    if llm_reranker is None or config.get("LLM_reranker", {}).get("backend") != "mlx":
+        return llm_reranker
+    gemma_retriever.llm_reranker = None
+    llm_reranker = None
+    gc.collect()
+    try:
+        import mlx.core as mx
+
+        before = mx.get_active_memory()
+        mx.clear_cache()
+        after = mx.get_active_memory()
+        logger.info("Released MLX reranker buffers: active memory %s -> %s.", before, after)
+    except (ImportError, RuntimeError) as exc:
+        logger.warning("Could not clear MLX reranker cache: %s", exc)
+    return llm_reranker
 
 
 def _maybe_write_report(output_folder, config) -> None:
@@ -684,6 +710,14 @@ def main_pipeline(
                         config,
                         patient_context,
                     )
+
+            # TAIM invokes TrialMatchAI once per patient. Release Gemma before
+            # constructing the Qwen eligibility processor so both MLX models do
+            # not remain resident in the same 24 GB unified-memory process.
+            if len(patient_inputs) == 1:
+                llm_reranker = _release_single_patient_mlx_reranker(
+                    gemma_retriever, llm_reranker, config
+                )
 
             if _rag_enabled(config):
                 with log_timing(logger, "RAG processing"):

--- a/src/trialmatchai/matching/eligibility_base.py
+++ b/src/trialmatchai/matching/eligibility_base.py
@@ -19,6 +19,30 @@ from tqdm import tqdm
 logger = setup_logging(__name__)
 
 
+_RECAP_FINAL_DECISION_MISSING_COMMA = re.compile(
+    r'("Recap"\s*:\s*"(?:\\.|[^"\\])*")(\s*)("Final Decision"\s*:)',
+    flags=re.DOTALL,
+)
+
+
+def _extract_eligibility_json(text: str) -> dict:
+    """Extract eligibility JSON, repairing one known model formatting mistake.
+
+    Some otherwise complete responses omit the comma between the ``Recap`` and
+    ``Final Decision`` fields. Repair only that exact boundary, then re-parse and
+    validate the result. Other malformed responses still fail normally.
+    """
+    try:
+        return extract_json_object(text)
+    except (json.JSONDecodeError, ValueError):
+        repaired, count = _RECAP_FINAL_DECISION_MISSING_COMMA.subn(r"\1,\2\3", text, count=1)
+        if count == 0:
+            raise
+        parsed = extract_json_object(repaired)
+        logger.warning("Repaired missing comma between Recap and Final Decision in model JSON")
+        return parsed
+
+
 def _is_error_output(path: str) -> bool:
     """True if a per-trial output is a recorded failure or unparseable, so the resume
     worklist retries it instead of locking a transient failure into the ranking."""
@@ -199,7 +223,7 @@ class BaseTrialProcessor:
             txt_path = f"{output_folder}/{nct_id}.txt"
             write_text_file([response], txt_path)
             try:
-                json_data = extract_json_object(self._strip_thinking_tags(response))
+                json_data = _extract_eligibility_json(self._strip_thinking_tags(response))
                 write_json_file(json_data, f"{output_folder}/{nct_id}.json")
                 logger.info(f"Processed {nct_id} successfully")
             except (json.JSONDecodeError, ValueError) as e:

--- a/src/trialmatchai/matching/eligibility_reasoning_mlx.py
+++ b/src/trialmatchai/matching/eligibility_reasoning_mlx.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from trialmatchai.matching.eligibility_base import BaseTrialProcessor
+from trialmatchai.models.llm.mlx_loader import MLXTextGenerator
+from trialmatchai.utils.file_utils import write_json_file
+from trialmatchai.utils.logging_config import setup_logging
+
+logger = setup_logging(__name__)
+
+
+class BatchTrialProcessorMLX(BaseTrialProcessor):
+    """Apple-Silicon eligibility processor backed by MLX-LM text generation."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        batch_size: int = 1,
+        use_cot: bool = True,
+        max_new_tokens: int = 256,
+        temperature: float = 0.0,
+        revision: str | None = None,
+        trust_remote_code: bool = False,
+        no_think: bool = False,
+    ):
+        self.generator = MLXTextGenerator(
+            model_path,
+            revision=revision,
+            trust_remote_code=trust_remote_code,
+        )
+        self.tokenizer = self.generator.tokenizer
+        self.batch_size = max(1, int(batch_size))
+        self.use_cot = use_cot
+        self.max_new_tokens = max(1, int(max_new_tokens))
+        self.temperature = max(0.0, float(temperature))
+        self.no_think = no_think
+        logger.info("Loaded MLX eligibility model %s.", model_path)
+
+    def _progress_desc(self) -> str:
+        return "MLX Processing Trials"
+
+    def _process_batch(self, batch: list[dict[str, Any]], output_folder: str):
+        # Keep the first implementation deliberately sequential. This is slower than a
+        # server-backed batch, but it is deterministic and keeps Apple unified memory bounded.
+        for item in batch:
+            try:
+                # BaseTrialProcessor already applies the tokenizer's chat template in
+                # _format_prompt. Applying it again here would wrap an already formatted
+                # conversation inside a second user message and degrade model output.
+                prompt = item["prompt"]
+                response = self.generator.generate_text(
+                    prompt,
+                    max_tokens=self.max_new_tokens,
+                    temperature=self.temperature,
+                )
+                self._save_outputs(item["nct_id"], response, output_folder)
+            except Exception as exc:
+                logger.error("MLX processing failed for %s: %s", item["nct_id"], exc)
+                os.makedirs(output_folder, exist_ok=True)
+                write_json_file(
+                    {"error": "processing_failed", "detail": str(exc)},
+                    os.path.join(output_folder, f"{item['nct_id']}.json"),
+                )

--- a/src/trialmatchai/matching/eligibility_reasoning_mlx_vlm.py
+++ b/src/trialmatchai/matching/eligibility_reasoning_mlx_vlm.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from trialmatchai.matching.eligibility_base import BaseTrialProcessor
+from trialmatchai.models.llm.mlx_vlm_loader import MLXVLMTextGenerator
+from trialmatchai.utils.file_utils import write_json_file
+from trialmatchai.utils.logging_config import setup_logging
+
+logger = setup_logging(__name__)
+
+
+class BatchTrialProcessorMLXVLM(BaseTrialProcessor):
+    """Eligibility processor for multimodal MLX-VLM models used with text only."""
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        batch_size: int = 1,
+        use_cot: bool = True,
+        max_new_tokens: int = 2048,
+        temperature: float = 0.0,
+        revision: str | None = None,
+        no_think: bool = False,
+    ):
+        self.generator = MLXVLMTextGenerator(model_path, revision=revision)
+        # Keep prompts plain in BaseTrialProcessor. MLX-VLM applies the template once
+        # immediately before generation, which avoids double-formatting.
+        self.tokenizer = None
+        self.batch_size = max(1, int(batch_size))
+        self.use_cot = use_cot
+        self.max_new_tokens = max(1, int(max_new_tokens))
+        self.temperature = max(0.0, float(temperature))
+        self.no_think = no_think
+        logger.info("Loaded MLX-VLM eligibility model %s.", model_path)
+
+    def _progress_desc(self) -> str:
+        return "MLX-VLM Processing Trials"
+
+    def _process_batch(self, batch: list[dict[str, Any]], output_folder: str):
+        for item in batch:
+            try:
+                response = self.generator.generate_text(
+                    item["prompt"],
+                    max_tokens=self.max_new_tokens,
+                    temperature=self.temperature,
+                    thinking=not self.no_think,
+                )
+                self._save_outputs(item["nct_id"], response, output_folder)
+            except Exception as exc:
+                logger.error("MLX-VLM processing failed for %s: %s", item["nct_id"], exc)
+                os.makedirs(output_folder, exist_ok=True)
+                write_json_file(
+                    {"error": "processing_failed", "detail": str(exc)},
+                    os.path.join(output_folder, f"{item['nct_id']}.json"),
+                )

--- a/src/trialmatchai/matching/query_expansion.py
+++ b/src/trialmatchai/matching/query_expansion.py
@@ -113,6 +113,14 @@ class QueryExpander:
             self._init_vllm()
         elif self.backend == "transformers":
             self._init_transformers()
+        elif self.backend == "mlx":
+            from trialmatchai.models.llm.mlx_loader import MLXTextGenerator
+
+            self.generator = MLXTextGenerator(
+                settings["model"],
+                revision=settings.get("model_revision"),
+                trust_remote_code=bool(settings.get("trust_remote_code", False)),
+            )
         else:
             raise ValueError(f"Unsupported query_expansion.backend: {self.backend}")
 
@@ -188,6 +196,14 @@ class QueryExpander:
                     pad_token_id=self.tokenizer.eos_token_id,
                 )
             return self.tokenizer.decode(out[0][prompt.shape[-1]:], skip_special_tokens=True)
+
+        if self.backend == "mlx":
+            prompt_text = self.generator.format_messages(messages)
+            return self.generator.generate_text(
+                prompt_text,
+                max_tokens=self.settings["max_new_tokens"],
+                temperature=0.0,
+            )
 
         # vllm
         from vllm import SamplingParams

--- a/src/trialmatchai/models/llm/mlx_loader.py
+++ b/src/trialmatchai/models/llm/mlx_loader.py
@@ -1,0 +1,70 @@
+"""Small optional MLX-LM loader for Apple Silicon text generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class MLXTextGenerator:
+    """Lazy-free wrapper around the public ``mlx_lm`` load/generate API.
+
+    MLX-LM exposes generated text rather than vLLM-style token log-probabilities.
+    Callers that need calibrated probabilities must record that they are using
+    a generated-label score instead.
+    """
+
+    model_path: str
+    revision: str | None = None
+    trust_remote_code: bool = False
+
+    def __post_init__(self) -> None:
+        try:
+            from mlx_lm import generate, load
+            from mlx_lm.sample_utils import make_sampler
+        except ImportError as exc:  # pragma: no cover - optional dependency guard
+            raise RuntimeError(
+                "MLX generation requires the mlx extra (`uv sync --extra mlx`)."
+            ) from exc
+
+        tokenizer_config: dict[str, Any] = {}
+        if self.trust_remote_code:
+            tokenizer_config["trust_remote_code"] = True
+        self.model, self.tokenizer = load(
+            self.model_path,
+            tokenizer_config=tokenizer_config or None,
+            revision=self.revision,
+        )
+        self._generate = generate
+        self._make_sampler = make_sampler
+
+    def format_messages(self, messages: list[dict[str, str]]) -> str:
+        template = getattr(self.tokenizer, "apply_chat_template", None)
+        if template is not None:
+            try:
+                return template(messages, tokenize=False, add_generation_prompt=True)
+            except (TypeError, ValueError):
+                pass
+        return "\n\n".join(
+            f"{message.get('role', 'user').title()}: {message.get('content', '')}"
+            for message in messages
+        ) + "\nAssistant:"
+
+    def generate_text(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 256,
+        temperature: float = 0.0,
+    ) -> str:
+        return str(
+            self._generate(
+                self.model,
+                self.tokenizer,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                sampler=self._make_sampler(temperature),
+                verbose=False,
+            )
+        ).strip()

--- a/src/trialmatchai/models/llm/mlx_loader.py
+++ b/src/trialmatchai/models/llm/mlx_loader.py
@@ -1,4 +1,4 @@
-"""Small optional MLX-LM loader for Apple Silicon text generation."""
+"""Small optional MLX-LM loader for Apple Silicon text generation and scoring."""
 
 from __future__ import annotations
 
@@ -8,12 +8,7 @@ from typing import Any
 
 @dataclass
 class MLXTextGenerator:
-    """Lazy-free wrapper around the public ``mlx_lm`` load/generate API.
-
-    MLX-LM exposes generated text rather than vLLM-style token log-probabilities.
-    Callers that need calibrated probabilities must record that they are using
-    a generated-label score instead.
-    """
+    """Wrapper around MLX-LM text generation and first-token log probabilities."""
 
     model_path: str
     revision: str | None = None
@@ -21,7 +16,7 @@ class MLXTextGenerator:
 
     def __post_init__(self) -> None:
         try:
-            from mlx_lm import generate, load
+            from mlx_lm import generate, load, stream_generate
             from mlx_lm.sample_utils import make_sampler
         except ImportError as exc:  # pragma: no cover - optional dependency guard
             raise RuntimeError(
@@ -37,6 +32,7 @@ class MLXTextGenerator:
             revision=self.revision,
         )
         self._generate = generate
+        self._stream_generate = stream_generate
         self._make_sampler = make_sampler
 
     def format_messages(self, messages: list[dict[str, str]]) -> str:
@@ -68,3 +64,51 @@ class MLXTextGenerator:
                 verbose=False,
             )
         ).strip()
+
+    def first_token_id(self, text: str) -> int:
+        """Return the first tokenizer ID for a label, matching upstream reranker behavior."""
+        try:
+            encoded = self.tokenizer(text, add_special_tokens=False)
+            token_ids = encoded["input_ids"]
+        except (TypeError, AttributeError):
+            token_ids = self.tokenizer.encode(text, add_special_tokens=False)
+        if token_ids and isinstance(token_ids[0], list):
+            token_ids = token_ids[0]
+        if not token_ids:
+            raise ValueError(f"Tokenizer could not encode {text!r}.")
+        return int(token_ids[0])
+
+    def first_token_logprobs(
+        self,
+        prompt: str,
+        token_ids: tuple[int, ...],
+        *,
+        temperature: float = 0.0,
+    ) -> dict[int, float]:
+        """Return selected first-token log probabilities for one prompt.
+
+        ``mlx_lm.generate`` returns decoded text only. ``stream_generate`` exposes the
+        log-probability vector on its first ``GenerationResponse``, which lets callers compute
+        the same two-class Yes/No probability used by the upstream reranker.
+        """
+        responses = self._stream_generate(
+            self.model,
+            self.tokenizer,
+            prompt=prompt,
+            max_tokens=1,
+            sampler=self._make_sampler(temperature),
+        )
+        response = next(iter(responses), None)
+        raw_logprobs = getattr(response, "logprobs", None)
+        if raw_logprobs is None:
+            return {}
+
+        scores: dict[int, float] = {}
+        for token_id in token_ids:
+            try:
+                value = raw_logprobs[int(token_id)]
+                value = value.item() if hasattr(value, "item") else value
+                scores[int(token_id)] = float(value)
+            except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+                continue
+        return scores

--- a/src/trialmatchai/models/llm/mlx_reranker.py
+++ b/src/trialmatchai/models/llm/mlx_reranker.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tqdm import tqdm
+
+from trialmatchai.models.llm.llm_reranker import LLMReranker
+from trialmatchai.models.llm.mlx_loader import MLXTextGenerator
+from trialmatchai.utils.logging_config import setup_logging
+
+logger = setup_logging(__name__)
+
+
+class MLXReranker:
+    """Apple-Silicon Yes/No reranker using deterministic MLX text generation.
+
+    Unlike vLLM and Transformers, the public MLX-LM generation API returns text rather than
+    next-token log-probabilities. The score is therefore a generated-label score (1.0 for Yes,
+    0.0 for No, 0.5 for an unrecognized answer) and must be recorded as such in provenance.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        batch_size: int = 1,
+        revision: str | None = None,
+        trust_remote_code: bool = False,
+    ):
+        self.generator = MLXTextGenerator(
+            model_path,
+            revision=revision,
+            trust_remote_code=trust_remote_code,
+        )
+        self.batch_size = max(1, int(batch_size))
+        logger.info("Loaded MLX reranker %s.", model_path)
+
+    def rank_pairs(self, patient_trial_pairs: list[tuple]) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        for start in tqdm(
+            range(0, len(patient_trial_pairs), self.batch_size),
+            desc="MLX reranking batches",
+        ):
+            batch = patient_trial_pairs[start : start + self.batch_size]
+            for patient_text, trial_text in batch:
+                prompt = self.generator.format_messages(
+                    LLMReranker.create_messages(patient_text, trial_text)
+                )
+                answer = self.generator.generate_text(
+                    prompt,
+                    max_tokens=1,
+                    temperature=0.0,
+                )
+                normalized = answer.strip().casefold()
+                if normalized.startswith("yes"):
+                    score, label = 1.0, "Yes"
+                elif normalized.startswith("no"):
+                    score, label = 0.0, "No"
+                else:
+                    score, label = 0.5, "Unknown"
+                results.append({"llm_score": score, "answer": label})
+        return results

--- a/src/trialmatchai/models/llm/mlx_reranker.py
+++ b/src/trialmatchai/models/llm/mlx_reranker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+from collections.abc import Mapping
 from typing import Any
 
 from tqdm import tqdm
@@ -12,12 +14,9 @@ logger = setup_logging(__name__)
 
 
 class MLXReranker:
-    """Apple-Silicon Yes/No reranker using deterministic MLX text generation.
+    """Apple-Silicon Yes/No reranker using first-token log probabilities from MLX-LM."""
 
-    Unlike vLLM and Transformers, the public MLX-LM generation API returns text rather than
-    next-token log-probabilities. The score is therefore a generated-label score (1.0 for Yes,
-    0.0 for No, 0.5 for an unrecognized answer) and must be recorded as such in provenance.
-    """
+    score_type = "binary_yes_probability"
 
     def __init__(
         self,
@@ -33,7 +32,28 @@ class MLXReranker:
             trust_remote_code=trust_remote_code,
         )
         self.batch_size = max(1, int(batch_size))
+        self.yes_token_id = self.generator.first_token_id("Yes")
+        self.no_token_id = self.generator.first_token_id("No")
+        if self.yes_token_id == self.no_token_id:
+            raise ValueError("Yes and No must map to different tokenizer IDs.")
         logger.info("Loaded MLX reranker %s.", model_path)
+
+    @staticmethod
+    def binary_yes_probability(
+        logprobs: Mapping[int, float], yes_token_id: int, no_token_id: int
+    ) -> tuple[float, bool]:
+        """Normalize the available Yes/No log probabilities and report availability."""
+        yes_lp = float(logprobs.get(yes_token_id, float("-inf")))
+        no_lp = float(logprobs.get(no_token_id, float("-inf")))
+        highest = max(yes_lp, no_lp)
+        if not math.isfinite(highest):
+            return 0.5, False
+        yes = math.exp(yes_lp - highest) if math.isfinite(yes_lp) else 0.0
+        no = math.exp(no_lp - highest) if math.isfinite(no_lp) else 0.0
+        total = yes + no
+        if total <= 0.0:
+            return 0.5, False
+        return yes / total, True
 
     def rank_pairs(self, patient_trial_pairs: list[tuple]) -> list[dict[str, Any]]:
         results: list[dict[str, Any]] = []
@@ -46,17 +66,23 @@ class MLXReranker:
                 prompt = self.generator.format_messages(
                     LLMReranker.create_messages(patient_text, trial_text)
                 )
-                answer = self.generator.generate_text(
+                logprobs = self.generator.first_token_logprobs(
                     prompt,
-                    max_tokens=1,
+                    (self.yes_token_id, self.no_token_id),
                     temperature=0.0,
                 )
-                normalized = answer.strip().casefold()
-                if normalized.startswith("yes"):
-                    score, label = 1.0, "Yes"
-                elif normalized.startswith("no"):
-                    score, label = 0.0, "No"
+                score, available = self.binary_yes_probability(
+                    logprobs, self.yes_token_id, self.no_token_id
+                )
+                if not available:
+                    label = "Unknown"
                 else:
-                    score, label = 0.5, "Unknown"
-                results.append({"llm_score": score, "answer": label})
+                    label = "Yes" if score > 0.5 else "No"
+                results.append(
+                    {
+                        "llm_score": score,
+                        "answer": label,
+                        "score_type": self.score_type,
+                    }
+                )
         return results

--- a/src/trialmatchai/models/llm/mlx_vlm_loader.py
+++ b/src/trialmatchai/models/llm/mlx_vlm_loader.py
@@ -1,0 +1,63 @@
+"""Optional MLX-VLM loader for multimodal Qwen3.5 checkpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MLXVLMTextGenerator:
+    """Generate text with an MLX-VLM model while using text-only prompts.
+
+    Qwen3.5 checkpoints are multimodal, but TrialMatchAI currently supplies text.
+    The VLM runtime still applies the model-specific chat template and returns the
+    generated text needed by the existing eligibility parser.
+    """
+
+    model_path: str
+    revision: str | None = None
+
+    def __post_init__(self) -> None:
+        try:
+            from mlx_vlm import generate, load
+            from mlx_vlm.prompt_utils import apply_chat_template
+            from mlx_vlm.utils import load_config
+        except ImportError as exc:  # pragma: no cover - optional dependency guard
+            raise RuntimeError(
+                "Qwen3.5 generation requires mlx-vlm (`uv sync --extra mlx-vlm`)."
+            ) from exc
+
+        self.model, self.processor = load(self.model_path, revision=self.revision)
+        self.config = load_config(self.model_path, revision=self.revision)
+        self._generate = generate
+        self._apply_chat_template = apply_chat_template
+
+    def format_prompt(self, prompt: str, *, thinking: bool = False) -> str:
+        return str(
+            self._apply_chat_template(
+                self.processor,
+                self.config,
+                prompt,
+                num_images=0,
+                enable_thinking=thinking,
+            )
+        )
+
+    def generate_text(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int = 512,
+        temperature: float = 0.0,
+        thinking: bool = False,
+    ) -> str:
+        formatted = self.format_prompt(prompt, thinking=thinking)
+        result = self._generate(
+            self.model,
+            self.processor,
+            formatted,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            verbose=False,
+        )
+        return str(getattr(result, "text", result)).strip()

--- a/src/trialmatchai/orchestration.py
+++ b/src/trialmatchai/orchestration.py
@@ -438,6 +438,13 @@ def _match_signature(config: Dict[str, Any]) -> dict:
     return {
         "reranker_backend": reranker.get("backend"),
         "reranker_enabled": reranker.get("enabled"),
+        # Changing MLX from generated-label scores to probability scores must invalidate cached
+        # matches even though the backend and model identity remain unchanged.
+        "reranker_score_contract": (
+            "binary_yes_probability_v1"
+            if reranker.get("backend") == "mlx"
+            else "backend_native"
+        ),
         # Model identity: swapping reranker/CoT weights or adapter must re-rank even on an unchanged corpus.
         "reranker_model": model.get("reranker_model_path"),
         "reranker_adapter": model.get("reranker_adapter_path"),

--- a/src/trialmatchai/orchestration.py
+++ b/src/trialmatchai/orchestration.py
@@ -10,6 +10,7 @@ over these stages, so idempotency behaves identically everywhere.
 from __future__ import annotations
 
 import json
+from itertools import islice
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, Sequence
 
@@ -186,16 +187,19 @@ def _reembed_docs_inplace(
     config: Dict[str, Any],
     trial_docs: list[dict],
     criteria_docs: list[dict],
-) -> None:
+    *,
+    embedder: Any | None = None,
+) -> Any:
     """Replace the corpus's pre-computed vectors with the config embedder's (document side).
 
     Without this, build_index reuses the prepare-time vectors, so an embedder swap never reaches
     retrieval — the query dim-mismatches the index and silently falls back to BM25. Empty text
     keeps an empty vector, matching registry.preparation._embed_texts.
     """
-    from trialmatchai.models.embedding import build_embedder
+    if embedder is None:
+        from trialmatchai.models.embedding import build_embedder
 
-    embedder = build_embedder(config)
+        embedder = build_embedder(config)
     embed_documents = getattr(embedder, "embed_documents", embedder.embed_texts)
 
     texts: list[str] = []
@@ -228,10 +232,13 @@ def _reembed_docs_inplace(
     for start in range(0, len(texts), chunk):
         batch = texts[start : start + chunk]
         vectors = embed_documents(batch)
-        for (doc, vector_field), vector in zip(slots[start : start + chunk], vectors):
+        for (doc, vector_field), vector in zip(
+            slots[start : start + chunk], vectors, strict=True
+        ):
             doc[vector_field] = list(vector)
         done += len(batch)
         logger.info("Re-embedded %s/%s texts", done, len(texts))
+    return embedder
 
 
 _EMBEDDER_SIDECAR = "_embedder.json"
@@ -326,8 +333,10 @@ def build_index(
         )
     # Validate BOTH corpora before writing any table, else an empty-criteria corpus leaves an
     # inconsistent index (trials but no criteria) where `ready_to_match` never becomes true.
-    criteria_docs = list(_iter_criteria_docs(Path(processed_criteria_folder), nct_set))
-    if not criteria_docs:
+    criteria_iter = iter(_iter_criteria_docs(Path(processed_criteria_folder), nct_set))
+    criteria_batch_size = 8192
+    first_criteria_batch = list(islice(criteria_iter, criteria_batch_size))
+    if not first_criteria_batch:
         raise RuntimeError(
             f"No criteria documents found in {processed_criteria_folder}"
             + (f" for the {len(nct_set)} filtered NCT ids" if nct_set else "")
@@ -337,13 +346,57 @@ def build_index(
     # Re-embed when requested or when an embedder swap was detected (auto_reembed), so retrieval
     # reaches the new embedder instead of the prepare-time vectors (see _reembed_docs_inplace).
     do_reembed = bool(search_cfg.get("reembed_index", False) or auto_reembed)
+    reembedder = None
+
+    # Trial documents are small enough to retain in memory. Criteria are not:
+    # re-embed and write one bounded batch at a time so the full corpus is never
+    # materialized as Python dictionaries, text strings, and vectors together.
     if do_reembed:
-        _reembed_docs_inplace(config, trial_docs, criteria_docs)
+        reembedder = _reembed_docs_inplace(
+            config,
+            trial_docs,
+            first_criteria_batch,
+            embedder=reembedder,
+        )
 
     n_trials = backend.index_trials(trial_docs, recreate=True)
     logger.info("Indexed %s trial documents.", n_trials)
 
-    n_criteria = backend.index_criteria(criteria_docs, recreate=True)
+    if do_reembed:
+        n_criteria = 0
+        batch = first_criteria_batch
+        recreate = True
+        while batch:
+            next_batch = list(islice(criteria_iter, criteria_batch_size))
+            if batch is not first_criteria_batch:
+                reembedder = _reembed_docs_inplace(
+                    config,
+                    [],
+                    batch,
+                    embedder=reembedder,
+                )
+            n_criteria += backend.index_criteria(
+                batch,
+                recreate=recreate,
+                create_indexes=not next_batch,
+            )
+            logger.info("Indexed %s criteria documents.", n_criteria)
+            batch = next_batch
+            recreate = False
+    else:
+        n_criteria = 0
+        batch = first_criteria_batch
+        recreate = True
+        while batch:
+            next_batch = list(islice(criteria_iter, criteria_batch_size))
+            n_criteria += backend.index_criteria(
+                batch,
+                recreate=recreate,
+                create_indexes=not next_batch,
+            )
+            logger.info("Indexed %s criteria documents.", n_criteria)
+            batch = next_batch
+            recreate = False
     logger.info("Indexed %s criteria documents.", n_criteria)
 
     # Record which embedder these vectors correspond to, so a later build auto-detects a swap.

--- a/src/trialmatchai/search/lancedb_backend.py
+++ b/src/trialmatchai/search/lancedb_backend.py
@@ -290,11 +290,13 @@ class LanceDBSearchBackend:
         docs: Sequence[Mapping[str, Any]],
         *,
         recreate: bool = True,
+        create_indexes: bool = True,
     ) -> int:
         rows = [build_criteria_record(doc) for doc in docs]
         table = self._write_rows(self.criteria_table, rows, recreate=recreate)
-        _create_fts_index(table, "search_text")
-        _create_vector_index(table, "criterion_vector")
+        if create_indexes:
+            _create_fts_index(table, "search_text")
+            _create_vector_index(table, "criterion_vector")
         return len(rows)
 
     def upsert_trials(self, docs: Sequence[Mapping[str, Any]]) -> int:

--- a/src/trialmatchai/services/preflight.py
+++ b/src/trialmatchai/services/preflight.py
@@ -93,6 +93,9 @@ def run_preflight_checks(
         needs_transformers = (rag_enabled and rag_backend == "transformers") or (
             reranker_enabled and reranker_backend == "transformers"
         )
+        needs_mlx = (rag_enabled and rag_backend in {"mlx", "mlx_vlm"}) or (
+            reranker_enabled and reranker_backend == "mlx"
+        )
         # vLLM is the production backend; CPU smoke configs use Transformers (no CUDA).
         if needs_vllm:
             vllm_available = importlib.util.find_spec("vllm") is not None
@@ -119,6 +122,10 @@ def run_preflight_checks(
                 issues.append(
                     "Transformers CPU backend requires transformers (`uv sync --extra llm`)."
                 )
+        if needs_mlx and importlib.util.find_spec("mlx_lm") is None:
+            issues.append("MLX backend requires mlx-lm (`uv sync --extra mlx`).")
+        if rag_enabled and rag_backend == "mlx_vlm" and importlib.util.find_spec("mlx_vlm") is None:
+            issues.append("MLX-VLM backend requires mlx-vlm (`uv sync --extra mlx-vlm`).")
 
         # Check gated base models up front so an HF auth failure surfaces here, not
         # after first-level search.

--- a/tests/test_audit_fixes_batch8.py
+++ b/tests/test_audit_fixes_batch8.py
@@ -612,7 +612,7 @@ def test_build_index_validates_criteria_before_writing_trials(tmp_path, monkeypa
             self.indexed_trials = True
             return len(list(docs))
 
-        def index_criteria(self, docs, recreate=True):
+        def index_criteria(self, docs, recreate=True, create_indexes=True):
             return len(list(docs))
 
     fake = FakeBackend()

--- a/tests/test_bootstrap_data.py
+++ b/tests/test_bootstrap_data.py
@@ -65,6 +65,61 @@ def test_bootstrap_data_uses_existing_archives_and_removes_them(tmp_path, monkey
     )
 
 
+def test_bootstrap_data_normalizes_legacy_processed_docs_directory(tmp_path, monkeypatch):
+    processed_archive = tmp_path / "data" / PROCESSED_TRIALS_ARCHIVE
+    processed_archive.parent.mkdir(parents=True)
+    _write_tar_gz(
+        processed_archive,
+        {"processed_docs/NCT000002.json": b'{"nct_id": "NCT000002"}'},
+    )
+    monkeypatch.setenv(
+        "TRIALMATCHAI_PROCESSED_TRIALS_SHA256", _sha256(processed_archive)
+    )
+
+    bootstrap_data(
+        root=tmp_path,
+        data_url="https://example.invalid/processed_trials.tar.gz",
+        criteria_chunks=0,
+    )
+
+    assert (tmp_path / "data/processed_trials/NCT000002.json").exists()
+    assert not (tmp_path / "data/processed_docs").exists()
+    assert (tmp_path / "data/processed_trials/.bootstrap_complete").exists()
+    assert not processed_archive.exists()
+
+
+def test_bootstrap_data_flattens_nested_processed_criteria_directory(tmp_path, monkeypatch):
+    processed_archive = tmp_path / "data" / PROCESSED_TRIALS_ARCHIVE
+    criteria_archive = tmp_path / "data" / "criteria_part_0.zip"
+    criteria_archive.parent.mkdir(parents=True)
+    _write_tar_gz(
+        processed_archive,
+        {"processed_trials/NCT000003.json": b'{"nct_id": "NCT000003"}'},
+    )
+    _write_zip(
+        criteria_archive,
+        {"processed_criteria/NCT000003/criterion.json": '{"nct_id": "NCT000003"}'},
+    )
+    monkeypatch.setenv(
+        "TRIALMATCHAI_PROCESSED_TRIALS_SHA256", _sha256(processed_archive)
+    )
+    monkeypatch.setenv("TRIALMATCHAI_CRITERIA_PART_0_SHA256", _sha256(criteria_archive))
+
+    bootstrap_data(
+        root=tmp_path,
+        data_url="https://example.invalid/processed_trials.tar.gz",
+        criteria_base_url="https://example.invalid",
+        criteria_chunks=1,
+    )
+
+    assert (tmp_path / "data/processed_criteria/NCT000003/criterion.json").exists()
+    assert not (tmp_path / "data/processed_criteria/processed_criteria").exists()
+    assert (tmp_path / "data/processed_criteria/.bootstrap_complete").exists()
+    assert (tmp_path / "data/processed_trials/NCT000003.json").exists()
+    assert not criteria_archive.exists()
+    assert not processed_archive.exists()
+
+
 def test_verify_sha256_rejects_mismatches(tmp_path):
     path = tmp_path / "artifact.txt"
     path.write_text("contents")

--- a/tests/test_index_provenance.py
+++ b/tests/test_index_provenance.py
@@ -27,7 +27,7 @@ class _FakeBackend:
         self.built = True
         return len(list(docs))
 
-    def index_criteria(self, docs, recreate=True):
+    def index_criteria(self, docs, recreate=True, create_indexes=True):
         return len(list(docs))
 
 
@@ -73,6 +73,49 @@ def test_build_auto_reembeds_on_embedder_swap(tmp_path, monkeypatch):
     assert reembed_calls == [1]
     sidecar = json.loads((fake.db_path / "_embedder.json").read_text())
     assert sidecar["identity"]["model_name"] == "ncbi/MedCPT-Article-Encoder"
+
+
+def test_reembedding_streams_criteria_batches(tmp_path, monkeypatch):
+    fake = _fake(tmp_path, monkeypatch)
+    trial_docs = [{"nct_id": "N1", "brief_title": "trial", "condition": "condition"}]
+    criteria_docs = [
+        {"nct_id": "N1", "criterion": f"criterion-{index}"}
+        for index in range(8193)
+    ]
+    monkeypatch.setattr(orch, "_iter_trial_docs", lambda *_args, **_kwargs: iter(trial_docs))
+    monkeypatch.setattr(
+        orch,
+        "_iter_criteria_docs",
+        lambda *_args, **_kwargs: iter(criteria_docs),
+    )
+    reembed_batch_sizes = []
+
+    def fake_reembed(_config, trial_batch, criteria_batch, **_kwargs):
+        reembed_batch_sizes.append((len(trial_batch), len(criteria_batch)))
+        return object()
+
+    monkeypatch.setattr(orch, "_reembed_docs_inplace", fake_reembed)
+    criteria_batch_sizes = []
+    original_index_criteria = fake.index_criteria
+
+    def record_index_criteria(docs, **kwargs):
+        criteria_batch_sizes.append(len(docs))
+        return original_index_criteria(docs, **kwargs)
+
+    monkeypatch.setattr(fake, "index_criteria", record_index_criteria)
+
+    result = orch.build_index(
+        {
+            "embedder": {"model_name": "BAAI/bge-m3", "normalize": True},
+            "search_backend": {"reembed_index": True},
+        },
+        processed_trials_folder=tmp_path / "unused-trials",
+        processed_criteria_folder=tmp_path / "unused-criteria",
+    )
+
+    assert result["criteria"] == 8193
+    assert criteria_batch_sizes == [8192, 1]
+    assert reembed_batch_sizes == [(1, 8192), (0, 1)]
 
 
 def test_no_sidecar_trusts_existing_index(tmp_path, monkeypatch):

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from trialmatchai.models.llm.mlx_loader import MLXTextGenerator
+
+
+def test_mlx_loader_passes_revision_and_generation_options(monkeypatch):
+    calls = {}
+
+    class Tokenizer:
+        def apply_chat_template(self, messages, **kwargs):
+            return f"formatted:{messages[0]['content']}"
+
+    def load(path, **kwargs):
+        calls["load"] = (path, kwargs)
+        return object(), Tokenizer()
+
+    def make_sampler(temperature):
+        calls["temperature"] = temperature
+        return "sampler"
+
+    def generate(model, tokenizer, **kwargs):
+        calls["generate"] = kwargs
+        return "answer"
+
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_lm",
+        types.SimpleNamespace(load=load, generate=generate),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_lm.sample_utils",
+        types.SimpleNamespace(make_sampler=make_sampler),
+    )
+
+    generator = MLXTextGenerator("mlx-community/example", revision="abc123")
+    assert calls["load"] == (
+        "mlx-community/example",
+        {"tokenizer_config": None, "revision": "abc123"},
+    )
+    assert generator.format_messages([{"role": "user", "content": "hello"}]) == "formatted:hello"
+    assert generator.generate_text("prompt", max_tokens=7, temperature=0.2) == "answer"
+    assert calls["temperature"] == 0.2
+    assert calls["generate"] == {
+        "prompt": "prompt",
+        "max_tokens": 7,
+        "sampler": "sampler",
+        "verbose": False,
+    }

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 import types
 
+import pytest
+
 from trialmatchai.models.llm.mlx_loader import MLXTextGenerator
 
 
@@ -25,10 +27,18 @@ def test_mlx_loader_passes_revision_and_generation_options(monkeypatch):
         calls["generate"] = kwargs
         return "answer"
 
+    def stream_generate(model, tokenizer, **kwargs):
+        calls["stream_generate"] = kwargs
+        yield types.SimpleNamespace(logprobs={7: -0.25, 8: -1.25})
+
     monkeypatch.setitem(
         sys.modules,
         "mlx_lm",
-        types.SimpleNamespace(load=load, generate=generate),
+        types.SimpleNamespace(
+            load=load,
+            generate=generate,
+            stream_generate=stream_generate,
+        ),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -49,4 +59,68 @@ def test_mlx_loader_passes_revision_and_generation_options(monkeypatch):
         "max_tokens": 7,
         "sampler": "sampler",
         "verbose": False,
+    }
+    assert generator.first_token_logprobs("prompt", (7, 8), temperature=0.0) == {
+        7: -0.25,
+        8: -1.25,
+    }
+    assert calls["stream_generate"] == {
+        "prompt": "prompt",
+        "max_tokens": 1,
+        "sampler": "sampler",
+    }
+
+
+def test_mlx_reranker_uses_binary_yes_probability(monkeypatch):
+    import trialmatchai.models.llm.mlx_reranker as reranker_module
+
+    class Generator:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def first_token_id(self, text):
+            return {"Yes": 7, "No": 8}[text]
+
+        def format_messages(self, messages):
+            return "formatted prompt"
+
+        def first_token_logprobs(self, prompt, token_ids, *, temperature):
+            assert prompt == "formatted prompt"
+            assert token_ids == (7, 8)
+            assert temperature == 0.0
+            return {7: -0.25, 8: -1.25}
+
+    monkeypatch.setattr(reranker_module, "MLXTextGenerator", Generator)
+    reranker = reranker_module.MLXReranker("example")
+    result = reranker.rank_pairs([("patient", "criterion")])[0]
+
+    assert result["score_type"] == "binary_yes_probability"
+    assert result["answer"] == "Yes"
+    assert result["llm_score"] == pytest.approx(0.7310586)
+
+
+def test_mlx_reranker_marks_missing_logprobs_unknown(monkeypatch):
+    import trialmatchai.models.llm.mlx_reranker as reranker_module
+
+    class Generator:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def first_token_id(self, text):
+            return {"Yes": 7, "No": 8}[text]
+
+        def format_messages(self, messages):
+            return "formatted prompt"
+
+        def first_token_logprobs(self, prompt, token_ids, *, temperature):
+            return {}
+
+    monkeypatch.setattr(reranker_module, "MLXTextGenerator", Generator)
+    reranker = reranker_module.MLXReranker("example")
+    result = reranker.rank_pairs([("patient", "criterion")])[0]
+
+    assert result == {
+        "llm_score": 0.5,
+        "answer": "Unknown",
+        "score_type": "binary_yes_probability",
     }

--- a/tests/test_resume_and_atomicity.py
+++ b/tests/test_resume_and_atomicity.py
@@ -350,6 +350,18 @@ def test_save_outputs_writes_error_sidecar_on_invalid_json(tmp_path):
     assert (tmp_path / "NCT9.txt").exists()  # raw reasoning still preserved
 
 
+def test_save_outputs_repairs_missing_recap_final_decision_comma(tmp_path):
+    from trialmatchai.matching.eligibility_base import BaseTrialProcessor
+
+    proc = BaseTrialProcessor.__new__(BaseTrialProcessor)
+    response = '{"Recap": "The patient is ineligible."\n"Final Decision": "Ineligible"}'
+    proc._save_outputs("NCT10", response, str(tmp_path))
+
+    data = json.loads((tmp_path / "NCT10.json").read_text())
+    assert data["Final Decision"] == "Ineligible"
+    assert "error" not in data
+
+
 # --- pipeline_state: stage-level skip/resume via fingerprinted completion state ---
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -47,6 +47,10 @@ class TestConfigLoading(unittest.TestCase):
         os.environ["TRIALMATCHAI_SEARCH_DB_PATH"] = "data/search-test"
         os.environ["TRIALMATCHAI_SEARCH_TRIALS_TABLE"] = "trials-test"
         os.environ["TRIALMATCHAI_SEARCH_MODE"] = "bm25"
+        os.environ["TRIALMATCHAI_RAG_BACKEND"] = "mlx"
+        os.environ["TRIALMATCHAI_RERANKER_BACKEND"] = "mlx"
+        os.environ["TRIALMATCHAI_MLX_MAX_NEW_TOKENS"] = "512"
+        os.environ["TRIALMATCHAI_RAG_NO_THINK"] = "true"
         os.environ["TRIALMATCHAI_EMBEDDER_MODEL_NAME"] = "new-model"
         os.environ["TRIALMATCHAI_ENTITY_BACKEND"] = "regex"
         os.environ["TRIALMATCHAI_CONCEPT_DB_PATH"] = "concepts"
@@ -66,6 +70,10 @@ class TestConfigLoading(unittest.TestCase):
             os.environ.pop("TRIALMATCHAI_SEARCH_DB_PATH", None)
             os.environ.pop("TRIALMATCHAI_SEARCH_TRIALS_TABLE", None)
             os.environ.pop("TRIALMATCHAI_SEARCH_MODE", None)
+            os.environ.pop("TRIALMATCHAI_RAG_BACKEND", None)
+            os.environ.pop("TRIALMATCHAI_RERANKER_BACKEND", None)
+            os.environ.pop("TRIALMATCHAI_MLX_MAX_NEW_TOKENS", None)
+            os.environ.pop("TRIALMATCHAI_RAG_NO_THINK", None)
             os.environ.pop("TRIALMATCHAI_EMBEDDER_MODEL_NAME", None)
             os.environ.pop("TRIALMATCHAI_ENTITY_BACKEND", None)
             os.environ.pop("TRIALMATCHAI_CONCEPT_DB_PATH", None)
@@ -83,6 +91,10 @@ class TestConfigLoading(unittest.TestCase):
         self.assertEqual(updated["search_backend"]["db_path"], "data/search-test")
         self.assertEqual(updated["search_backend"]["trials_table"], "trials-test")
         self.assertEqual(updated["search"]["mode"], "bm25")
+        self.assertEqual(updated["rag"]["backend"], "mlx")
+        self.assertEqual(updated["LLM_reranker"]["backend"], "mlx")
+        self.assertEqual(updated["mlx"]["max_new_tokens"], 512)
+        self.assertTrue(updated["rag"]["no_think"])
         self.assertEqual(updated["embedder"]["model_name"], "new-model")
         self.assertEqual(updated["entity_extraction"]["backend"], "regex")
         self.assertEqual(updated["concept_linker"]["db_path"], "concepts")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -63,6 +63,7 @@ class TestConfigLoading(unittest.TestCase):
         os.environ["TRIALMATCHAI_FIRST_LEVEL_ENABLED"] = "false"
         os.environ["TRIALMATCHAI_FIRST_LEVEL_MAX_TRIALS"] = "700"
         os.environ["TRIALMATCHAI_FIRST_LEVEL_PER_CHANNEL_SIZE"] = "250"
+        os.environ["TRIALMATCHAI_SEARCH_SECOND_LEVEL_KEEP_DIVISOR"] = "1"
         os.environ["TRIALMATCHAI_FIRST_LEVEL_VECTOR_SCORE_THRESHOLD"] = "0.1"
         try:
             updated = apply_env_overrides(raw)
@@ -86,6 +87,7 @@ class TestConfigLoading(unittest.TestCase):
             os.environ.pop("TRIALMATCHAI_FIRST_LEVEL_ENABLED", None)
             os.environ.pop("TRIALMATCHAI_FIRST_LEVEL_MAX_TRIALS", None)
             os.environ.pop("TRIALMATCHAI_FIRST_LEVEL_PER_CHANNEL_SIZE", None)
+            os.environ.pop("TRIALMATCHAI_SEARCH_SECOND_LEVEL_KEEP_DIVISOR", None)
             os.environ.pop("TRIALMATCHAI_FIRST_LEVEL_VECTOR_SCORE_THRESHOLD", None)
 
         self.assertEqual(updated["search_backend"]["db_path"], "data/search-test")
@@ -107,6 +109,7 @@ class TestConfigLoading(unittest.TestCase):
         self.assertFalse(updated["search"]["first_level"]["enabled"])
         self.assertEqual(updated["search"]["first_level"]["max_trials"], 700)
         self.assertEqual(updated["search"]["first_level"]["per_channel_size"], 250)
+        self.assertEqual(updated["search"]["second_level_keep_divisor"], 1)
         self.assertEqual(updated["search"]["first_level"]["vector_score_threshold"], 0.1)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -15,14 +15,14 @@ name = "accelerate"
 version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "psutil", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "safetensors", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "torch", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/c2/b9e33ad13232606dded4c546e654fb06a15f1dbcbd95d81c9f9dd3ccc771/accelerate-1.8.1.tar.gz", hash = "sha256:f60df931671bc4e75077b852990469d4991ce8bd3a58e72375c3c95132034db9", size = 380872, upload-time = "2025-06-20T15:36:14.618Z" }
 wheels = [
@@ -43,14 +43,14 @@ name = "aiohttp"
 version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "aiosignal", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "attrs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "frozenlist", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "multidict", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "propcache", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "yarl", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "typing-extensions" },
+    { name = "yarl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
@@ -66,8 +66,8 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "frozenlist" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -97,14 +97,14 @@ name = "anthropic"
 version = "0.111.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "distro", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "docstring-parser", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "httpx", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "jiter", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "sniffio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/8a/9afc7305a2ce4b52b30e137f83cd2a6a90b918b3997073db11bb5a1de55a/anthropic-0.111.0.tar.gz", hash = "sha256:39cbda0ac17a6d423e5bf609811bd69b26eddf6299d7a468126e05bc711ce826", size = 934001, upload-time = "2026-06-18T17:31:44.733Z" }
 wheels = [
@@ -116,8 +116,8 @@ name = "anyio"
 version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "idna" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
 wheels = [
@@ -129,7 +129,7 @@ name = "apache-tvm-ffi"
 version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/60/1e787a0b5ebf318483235be2a689ee367173983067e441b8379564f667c0/apache_tvm_ffi-0.1.9.tar.gz", hash = "sha256:d2d402587e8906de0a07f4746aa78f3d452c7efe3625d4bb39ac2ad693bce530", size = 2513731, upload-time = "2026-02-27T19:28:06.602Z" }
 wheels = [
@@ -181,9 +181,9 @@ name = "bitsandbytes"
 version = "0.49.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "torch" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/57/3443d6f183436fbdaf5000aac332c4d5ddb056665d459244a5608e98ae92/bitsandbytes-0.49.2-py3-none-manylinux_2_24_x86_64.whl", hash = "sha256:54b771f06e1a3c73af5c7f16ccf0fc23a846052813d4b008d10cb6e017dd1c8c", size = 60651714, upload-time = "2026-02-16T21:26:11.579Z" },
@@ -194,7 +194,7 @@ name = "blake3"
 version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/75/aa/abcd75e9600987a0bc6cfe9b6b2ff3f0e2cb08c170addc6e76035b5c4cb3/blake3-1.0.8.tar.gz", hash = "sha256:513cc7f0f5a7c035812604c2c852a0c1468311345573de647e310aca4ab165ba", size = 117308, upload-time = "2025-10-14T06:47:48.83Z" }
 wheels = [
@@ -216,8 +216,8 @@ name = "cachecontrol"
 version = "0.14.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "msgpack", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "requests", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "msgpack" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
 wheels = [
@@ -226,7 +226,7 @@ wheels = [
 
 [package.optional-dependencies]
 filecache = [
-    { name = "filelock", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "filelock" },
 ]
 
 [[package]]
@@ -262,10 +262,12 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
     { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
     { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
 ]
@@ -323,10 +325,10 @@ name = "compressed-tensors"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "loguru", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "transformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "loguru" },
+    { name = "pydantic" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2c/9e/d7f18bd9a0354088abc11a0c1f2c7698f7c49e5a709faedf6a46e388f693/compressed_tensors-0.17.0.tar.gz", hash = "sha256:15c20d06bdbcf35b51fc99fd125e7b9be1e1855567c33b7a46dfac26ad6fb126", size = 257091, upload-time = "2026-06-03T16:49:17.208Z" }
 wheels = [
@@ -338,7 +340,7 @@ name = "cryptography"
 version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -359,7 +361,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
@@ -370,8 +372,8 @@ name = "cuda-core"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-pathfinder" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/55/bb3e701f4af504e5e39e837135dc80022ec4c84858b2886ad577fe696a77/cuda_core-1.0.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1934517ff8a9dcd21b3f4a28e15e12643164b7d3ec187a4ee7560e22fd2dfc17", size = 5059041, upload-time = "2026-05-12T20:11:26.045Z" },
@@ -390,9 +392,9 @@ name = "cuda-python"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "cuda-core", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "cuda-pathfinder", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-bindings" },
+    { name = "cuda-core" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/31/7ff3f7768eded7535c621abc2fecb9d181a34ea4cae3afe682feb796f242/cuda_python-13.3.1-py3-none-any.whl", hash = "sha256:280b014139ab447b6dd70a377db1596f310d6e887d9d342e6651b919ec145fb3", size = 8295, upload-time = "2026-05-29T23:28:47.012Z" },
@@ -403,7 +405,7 @@ name = "cuda-tile"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/2d/8b416239413bf11d17d42ccee43258f3787da13bcea7b2e42e8bbf04b3da/cuda_tile-1.3.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:2888d6b89fae053a53ca7bb703c508a5cf90671d266934573c5b6c25978022c4", size = 246706, upload-time = "2026-04-20T15:51:03.467Z" },
@@ -411,9 +413,9 @@ wheels = [
 
 [package.optional-dependencies]
 tileiras = [
-    { name = "nvidia-cuda-nvcc", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-tileiras", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvvm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc" },
+    { name = "nvidia-cuda-tileiras" },
+    { name = "nvidia-nvvm" },
 ]
 
 [[package]]
@@ -426,37 +428,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -464,11 +466,11 @@ name = "cyclonedx-python-lib"
 version = "11.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "license-expression", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "packageurl-python", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "py-serializable", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "sortedcontainers", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "license-expression" },
+    { name = "packageurl-python" },
+    { name = "py-serializable" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/75/c9/5d0ccdd19bc7d8ab803b90695c1706aa2ea8529685d18e682dc2524d2630/cyclonedx_python_lib-11.11.0.tar.gz", hash = "sha256:4b3194db72b613717f2912447e67ab618c75ff7dcac6c4af3c0e9e1ac617c102", size = 1442983, upload-time = "2026-06-17T11:57:49.055Z" }
 wheels = [
@@ -480,21 +482,21 @@ name = "datasets"
 version = "4.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "filelock", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "fsspec", extra = ["http"], marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "httpx", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "huggingface-hub", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "multiprocess", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pandas", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyarrow", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "requests", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "xxhash", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "dill" },
+    { name = "filelock" },
+    { name = "fsspec", extra = ["http"] },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "multiprocess" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "xxhash" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/34/14cd8e76f907f7d4dca2334cfeec9f81d30fd15c25a015f99aaea694eaed/datasets-4.8.5.tar.gz", hash = "sha256:0f0c1c3d56ffff2c93b2f4c63c95bac94f3d7e8621aea2a2a576275233bba772", size = 605649, upload-time = "2026-04-27T15:43:57.384Z" }
 wheels = [
@@ -515,7 +517,7 @@ name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
@@ -527,8 +529,8 @@ name = "depyf"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "astor", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "dill", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "astor" },
+    { name = "dill" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/35/83fb0178212279aa0af031031905804c6de5618435d229f41ed21bb9ad2c/depyf-0.20.0.tar.gz", hash = "sha256:fb7683bd72c44f67b56029df2c47721e9a02ffa4d7b19095f1c54c4ebf797a98", size = 6168761, upload-time = "2025-10-13T12:33:38.589Z" }
 wheels = [
@@ -612,8 +614,8 @@ name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dnspython", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "idna", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "dnspython" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
@@ -625,11 +627,11 @@ name = "fastapi"
 version = "0.136.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-inspection", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
@@ -638,15 +640,15 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "email-validator", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "fastapi-cli", extra = ["standard"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "fastar", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "httpx", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "jinja2", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic-extra-types", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic-settings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "python-multipart", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "uvicorn", extra = ["standard"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "email-validator" },
+    { name = "fastapi-cli", extra = ["standard"] },
+    { name = "fastar" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "pydantic-extra-types" },
+    { name = "pydantic-settings" },
+    { name = "python-multipart" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [[package]]
@@ -654,9 +656,9 @@ name = "fastapi-cli"
 version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "rich-toolkit", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typer", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "uvicorn", extra = ["standard"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "rich-toolkit" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/d0/ee5678346811967b8d096d5d5604e71b50d6bf5a2abfbdb331157e2bbaa9/fastapi_cli-0.0.27.tar.gz", hash = "sha256:1dffb1e40c0c88f2e0171a8a252a2b615c1e63ff8c05626649e4badd6a84336a", size = 23630, upload-time = "2026-06-18T14:48:43.421Z" }
 wheels = [
@@ -665,8 +667,8 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "fastapi-cloud-cli", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "uvicorn", extra = ["standard"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "fastapi-cloud-cli" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [[package]]
@@ -674,15 +676,15 @@ name = "fastapi-cloud-cli"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "detect-installer", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "fastar", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "httpx", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", extra = ["email"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "rich-toolkit", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "rignore", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "sentry-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typer", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "uvicorn", extra = ["standard"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "detect-installer" },
+    { name = "fastar" },
+    { name = "httpx" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "rich-toolkit" },
+    { name = "rignore" },
+    { name = "sentry-sdk" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/bf/97d19633c6ec6fb0ef59df474b9705ea992f7b4f879208d0007ac6d25ab6/fastapi_cloud_cli-0.20.0.tar.gz", hash = "sha256:9681c46adcd299024d0775658bd5d88992fd35c4ad42b1f045c6df913390ba37", size = 85904, upload-time = "2026-06-11T17:41:02.814Z" }
 wheels = [
@@ -706,7 +708,7 @@ name = "fastsafetensors"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typer", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c8/33/c97b2bcbe06e0f011eedee0f41d4060f6344901a53c2703acc3dd7429713/fastsafetensors-0.3.2.tar.gz", hash = "sha256:9e358fce238684613a5c3ebb7800c52c5b3270c0bb5e4ed2191ee8f3d0431de1", size = 70409, upload-time = "2026-05-22T05:39:34.787Z" }
 wheels = [
@@ -735,20 +737,20 @@ name = "flashinfer-python"
 version = "0.6.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "click", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "cuda-tile", extra = ["tileiras"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "ninja", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-frontend", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cutlass-dsl", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-ml-py", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tabulate", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "apache-tvm-ffi" },
+    { name = "click" },
+    { name = "cuda-tile", extra = ["tileiras"] },
+    { name = "einops" },
+    { name = "ninja" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cudnn-frontend" },
+    { name = "nvidia-cutlass-dsl" },
+    { name = "nvidia-ml-py" },
+    { name = "packaging" },
+    { name = "requests" },
+    { name = "tabulate" },
+    { name = "torch" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/d0/114a64319f5a804def2f307d5ed8f95e6d94a2acdacac4ed5f57525cbf46/flashinfer_python-0.6.12.tar.gz", hash = "sha256:bed67f9c46d81dd22611dfef2787998fc412b2fe2648d9e7d336861dda912694", size = 9453326, upload-time = "2026-05-29T23:45:16.466Z" }
 wheels = [
@@ -788,7 +790,7 @@ wheels = [
 
 [package.optional-dependencies]
 http = [
-    { name = "aiohttp", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "aiohttp" },
 ]
 
 [[package]]
@@ -796,10 +798,10 @@ name = "gguf"
 version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/ae/17f1308ae45cd7b08ebb521747d5b23f4efc4d172038a4e228dd5106c3ff/gguf-0.19.0.tar.gz", hash = "sha256:dbadcd6cc7ccd44256f2229fe7c2dff5e8aa5cf0612ab987fd2b1a57e428923f", size = 111220, upload-time = "2026-05-06T13:04:03.667Z" }
 wheels = [
@@ -811,7 +813,7 @@ name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
@@ -820,19 +822,19 @@ wheels = [
 
 [[package]]
 name = "gliner"
-version = "0.2.27"
+version = "0.2.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "onnxruntime", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "sentencepiece", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "torch", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "transformers", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "huggingface-hub" },
+    { name = "onnxruntime" },
+    { name = "sentencepiece" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/37/c456f6be21a95ed2c635d00bd6049d99a3b31490129a2b19965b0a60ec58/gliner-0.2.27.tar.gz", hash = "sha256:071de0819d83c34468ede02f75a38f618bc0c69262582127dccf3bb787db4c0c", size = 225241, upload-time = "2026-06-15T14:38:38.422Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/6d/677d50855311e4a1286204c5ef2ef5672d01688246a303bde5326311bdad/gliner-0.2.24.tar.gz", hash = "sha256:191a37d1b3d297927c37ae890ce904e9d4e9d3f4c8e19715e77a9876e5f8a575", size = 160568, upload-time = "2025-11-26T18:20:32.867Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/48/9b6dc122f53d5493d280a797e7781143b5a86a2625b8550d6b082eb7fb46/gliner-0.2.27-py3-none-any.whl", hash = "sha256:90373a3f6166977d4ca807c5daf6e3ea1fa21a5c40d862f3e63764cba442abae", size = 207786, upload-time = "2026-06-15T14:38:36.08Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/50/6aae23929bd019300ef13fb79d60609215c53d4541963eaffc438e62f77e/gliner-0.2.24-py3-none-any.whl", hash = "sha256:efe614e05b31d06d848373aef8270f567e34fe1b4e96f816a8c70cef24908a6c", size = 151880, upload-time = "2025-11-26T18:20:28.801Z" },
 ]
 
 [[package]]
@@ -840,11 +842,11 @@ name = "gliner2"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "gliner", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "peft", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pydantic", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "requests", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "urllib3", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "gliner" },
+    { name = "peft" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/1c/5e7e30213e8d917c14cefa3c060457bfa6a1e21304f852f02400dba91715/gliner2-1.3.1.tar.gz", hash = "sha256:c22f496afb2c87640005f5f49f83bb42610e85e544e3170cff7ea1ba69925ffa", size = 132379, upload-time = "2026-05-06T16:15:59.58Z" }
 wheels = [
@@ -856,7 +858,7 @@ name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
 wheels = [
@@ -877,7 +879,7 @@ name = "grpcio"
 version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
 wheels = [
@@ -911,8 +913,8 @@ name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "h11", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "certifi" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
@@ -934,10 +936,10 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "certifi", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "httpcore", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "idna", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -958,16 +960,16 @@ name = "huggingface-hub"
 version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "filelock", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "hf-xet", marker = "(platform_machine == 'AMD64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'amd64' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "httpx", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "typer", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or sys_platform == 'linux'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e6/7e/fad82ad491b226e832d2da90a1a59f36acd4526cda8c726f639834754aa4/huggingface_hub-1.20.1.tar.gz", hash = "sha256:9f6d63bfbeab2d2a8357200a9bc4f18cd2c8bfac9579f792f5922e77bf6471d0", size = 859910, upload-time = "2026-06-18T22:06:53.348Z" }
 wheels = [
@@ -979,16 +981,16 @@ name = "humming-kernels"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "jinja2", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-ml-py", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pyelftools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "safetensors", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tabulate", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-bindings" },
+    { name = "jinja2" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-ml-py" },
+    { name = "pyelftools" },
+    { name = "safetensors" },
+    { name = "tabulate" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "triton" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/f6/05e95b66cca48def9db0d6c40374fe285c7d9c913fe126030bcfb7cb3088/humming_kernels-0.1.4.tar.gz", hash = "sha256:fdaf4f23cc6b03bb1be3fd24aa11dc7798881e5448826e2404b4f12d8096f0d0", size = 117555, upload-time = "2026-06-04T03:24:03.504Z" }
 wheels = [
@@ -997,10 +999,10 @@ wheels = [
 
 [package.optional-dependencies]
 cu13 = [
-    { name = "nvidia-cuda-cccl", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvcc", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cccl" },
+    { name = "nvidia-cuda-nvcc" },
+    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-runtime" },
 ]
 
 [[package]]
@@ -1055,7 +1057,7 @@ name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
@@ -1087,10 +1089,10 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "jsonschema-specifications", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "referencing", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "rpds-py", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -1102,7 +1104,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "referencing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -1114,7 +1116,7 @@ name = "lance-namespace"
 version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lance-namespace-urllib3-client", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "lance-namespace-urllib3-client" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/af/12/f7ab93b29be3edbf5fc3610714bf2d06088e7f4524bfb38dfd6852458b08/lance_namespace-0.8.6.tar.gz", hash = "sha256:18232e721c8188145f4ec9389cc2dfbeeabf54a619d94885ea1b3375bee9f4af", size = 11529, upload-time = "2026-06-12T17:36:41.651Z" }
 wheels = [
@@ -1126,10 +1128,10 @@ name = "lance-namespace-urllib3-client"
 version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "python-dateutil", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "urllib3", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/80/fb224b4a89c1c1638cde949cb6cce6c3aca7759effbfea46a3d9c3960b21/lance_namespace_urllib3_client-0.8.6.tar.gz", hash = "sha256:b6fb1d306e74a7576e5309919020be744527de484a63dbf5eed10f8b368548df", size = 228772, upload-time = "2026-06-12T17:36:42.609Z" }
 wheels = [
@@ -1141,15 +1143,15 @@ name = "lancedb"
 version = "0.25.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "lance-namespace", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "overrides", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyarrow", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pydantic", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "deprecation" },
+    { name = "lance-namespace" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "overrides" },
+    { name = "packaging" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "tqdm" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/62/a149b47dc4ccf3c569eba722b805cbba1b90566976ff1d459f20f7f00ebc/lancedb-0.25.3-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:1cfa4dd97b33ca8f73288aa4b1baaddc9545ce0d3c8e5d06fba8feb77f42363f", size = 38425074, upload-time = "2025-11-07T05:58:15.763Z" },
@@ -1172,7 +1174,7 @@ name = "license-expression"
 version = "30.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "boolean-py", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "boolean-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/71/d89bb0e71b1415453980fd32315f2a037aad9f7f70f695c7cec7035feb13/license_expression-30.4.4.tar.gz", hash = "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd", size = 186402, upload-time = "2025-07-22T11:13:32.17Z" }
 wheels = [
@@ -1185,6 +1187,8 @@ version = "1.7.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/91/6bc8bb503dc259e46d253b5424385a54fe06c38a4c7a12befe69a3c2455a/llguidance-1.7.6.tar.gz", hash = "sha256:db7febbe412ed2015501904646750071d7e00e6df7f85c4b956ad4f206fd2df7", size = 1156574, upload-time = "2026-06-03T20:13:25.316Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/1d/5a9a13421b1f3f1c1acf82beb63ed72fa4d302e65099b72f4a4fe5a098ab/llguidance-1.7.6-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:eabf4572c8731734c0444c353b9ea06bc5c156986d2ff0a4ec0499159271381f", size = 3227892, upload-time = "2026-06-03T20:13:09.533Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fe/bb185f11bad82f2637e3cd8cbf6b200cbb6ed56ac395de47ea05a60d4649/llguidance-1.7.6-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:9c54c899db8cb4b4fba128a7d844730066576c70d806c95ada92b2bd2d6ab498", size = 3138127, upload-time = "2026-06-03T20:13:11.649Z" },
     { url = "https://files.pythonhosted.org/packages/1a/64/d74336f22242ef94356a456057d4ff1be7c1bc9c7dbc867171c6982a5512/llguidance-1.7.6-cp39-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:ceec951d29a74309984e3be0fe7f5f56c1362434cd937abd517b259a60908b1e", size = 3074809, upload-time = "2026-06-03T20:13:15.498Z" },
 ]
 
@@ -1202,10 +1206,10 @@ name = "lm-format-enforcer"
 version = "0.11.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "interegular", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "interegular" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/d5/41cd417ba7dfdbbcfe46cebf81fb3dfd7c591b89897560ad05bb410a465d/lm_format_enforcer-0.11.3.tar.gz", hash = "sha256:e68081c108719cce284a9bcc889709b26ffb085a1945b5eba3a12cfa96d528da", size = 40258, upload-time = "2025-08-24T19:37:47.527Z" }
 wheels = [
@@ -1235,7 +1239,7 @@ name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdurl", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "mdurl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
@@ -1259,19 +1263,19 @@ name = "mcp"
 version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "httpx", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "httpx-sse", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "jsonschema", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic-settings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pyjwt", extra = ["crypto"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "python-multipart", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "sse-starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-inspection", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
 wheels = [
@@ -1297,18 +1301,31 @@ wheels = [
 ]
 
 [[package]]
+name = "miniaudio"
+version = "1.71"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/d5/e5439dc08561f73656bfeb3340fc64ab63163e101426593d8fb9a025ff1e/miniaudio-1.71.tar.gz", hash = "sha256:ff51e2887bb673e2e757752b586b3dc924d59aa5fbcae9bbc45f4a111bd3262b", size = 1116480, upload-time = "2026-04-29T21:20:38.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/1a/8ded8b04490e0d50e2a404fc99858163c9567a135eaab35990b42bdfad72/miniaudio-1.71-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ac4a37ebbbfbfbeca50f4390e50f9952807ca61ac62f0c3bcbbc7dd698531dd3", size = 367726, upload-time = "2026-04-29T21:20:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c1/4b13ac3c36a2574e0d70f322246d80259606cd24523279f542abc9ac6063/miniaudio-1.71-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5009b4e29cd43de3631d2d5ab09cc074192c085b4c8dd8a121b856ce1af6bab7", size = 351405, upload-time = "2026-04-29T21:20:10.533Z" },
+]
+
+[[package]]
 name = "mistral-common"
 version = "1.11.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pillow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic-extra-types", extra = ["pycountry"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tiktoken", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "jsonschema" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "pydantic-extra-types", extra = ["pycountry"] },
+    { name = "requests" },
+    { name = "tiktoken" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/03/3c5d4c9430da406f8444f9a7b058a6aa89c525fb068a57fe2ab8b04a6d08/mistral_common-1.11.3.tar.gz", hash = "sha256:6437e128fc8a307318440839ca14ddf2e8060056b062233ec0db10352651374c", size = 6360629, upload-time = "2026-06-04T09:01:11.131Z" }
 wheels = [
@@ -1317,7 +1334,7 @@ wheels = [
 
 [package.optional-dependencies]
 image = [
-    { name = "opencv-python-headless", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opencv-python-headless" },
 ]
 
 [[package]]
@@ -1325,18 +1342,18 @@ name = "mkdocs"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "ghp-import", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "markdown", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "markupsafe", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "mergedeep", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "mkdocs-get-deps", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pathspec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyyaml-env-tag", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "watchdog", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "click" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
 wheels = [
@@ -1348,9 +1365,9 @@ name = "mkdocs-autorefs"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "markupsafe", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "mkdocs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
 wheels = [
@@ -1362,9 +1379,9 @@ name = "mkdocs-get-deps"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mergedeep", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "platformdirs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
 wheels = [
@@ -1376,17 +1393,17 @@ name = "mkdocs-material"
 version = "9.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "babel", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "backrefs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "colorama", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "markdown", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "mkdocs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "mkdocs-material-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "paginate", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pygments", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pymdown-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "requests", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
 wheels = [
@@ -1407,12 +1424,12 @@ name = "mkdocstrings"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "markdown", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "markupsafe", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "mkdocs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "mkdocs-autorefs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pymdown-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/5d/f888d4d3eb31359b327bc9b17a212d6ef03fe0b0682fbb3fc2cb849fb12b/mkdocstrings-1.0.4.tar.gz", hash = "sha256:3969a6515b77db65fd097b53c1b7aa4ae840bd71a2ee62a6a3e89503446d7172", size = 100088, upload-time = "2026-04-15T09:16:53.376Z" }
 wheels = [
@@ -1421,7 +1438,7 @@ wheels = [
 
 [package.optional-dependencies]
 python = [
-    { name = "mkdocstrings-python", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "mkdocstrings-python" },
 ]
 
 [[package]]
@@ -1429,9 +1446,9 @@ name = "mkdocstrings-python"
 version = "2.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "griffelib", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "mkdocs-autorefs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "mkdocstrings", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/b6/e858701499d57eee8b3fd8e78168083956c6683ddbe727b46758b19e1119/mkdocstrings_python-2.0.5.tar.gz", hash = "sha256:3a4d92556ad39637e88af94a5374213af9a8e3040c3824ceaed04b486c017594", size = 199578, upload-time = "2026-06-19T10:41:08.868Z" }
 wheels = [
@@ -1443,7 +1460,7 @@ name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
 wheels = [
@@ -1451,17 +1468,104 @@ wheels = [
 ]
 
 [[package]]
+name = "mlx"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mlx-metal" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/c7/cb62301b01dbccd66b256cab0c98fc29e7533dd76aa599fe44c1bb1f4168/mlx-0.32.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:72c605368d145c756877057d7e3c54f169c9899fe1f83232bfb3a6342561e234", size = 562792, upload-time = "2026-07-07T17:55:35.24Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b1/c2eba5bb18c94a9fe1b5d6599f18ba2ef5de2d8b42439716d9241ab196c4/mlx-0.32.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:0a0e38a409b9cae29647ec9e75ce9747b224ce7e5d91adbfad7eac37b6118ffd", size = 562792, upload-time = "2026-07-07T17:55:36.876Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/43/5b481bfb8f1234153fd8fef9dcacfe34860b0934eb507c0eb811ba599afe/mlx-0.32.0-cp311-cp311-macosx_26_0_arm64.whl", hash = "sha256:2a180cd39ac68b397b85cc4658d0b8e0ab58166c2549fc9ab2ca5f99d15ef0c3", size = 562776, upload-time = "2026-07-07T17:55:38.314Z" },
+]
+
+[[package]]
+name = "mlx-audio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "miniaudio" },
+    { name = "mlx" },
+    { name = "mlx-lm" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy" },
+    { name = "sounddevice" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/1e/f712c9f7997e5051c4da3b658f38162203bb703c750741984c8358c8b897/mlx_audio-0.4.4.tar.gz", hash = "sha256:d751e5f477517e4e7f04de5567318e2fe91b4606af5d7e4b2973603c4777814a", size = 1386491, upload-time = "2026-06-06T15:32:03.504Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/4d/93ac0e0526591c856a1ea2cd00a41f31530d9e021cc95bc9400550926d51/mlx_audio-0.4.4-py3-none-any.whl", hash = "sha256:39fe81b03e2b1354be70de82dc8bf01dd6e75efcb464150afef89f18f734d0d5", size = 1669932, upload-time = "2026-06-06T15:32:01.807Z" },
+]
+
+[[package]]
+name = "mlx-lm"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mlx" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "protobuf", version = "7.35.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyyaml" },
+    { name = "sentencepiece" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/02/9a67b8e4f87e3e2e5cd7b1ad79304b93c09a0db6af34bee75e6551c06c60/mlx_lm-0.31.3-py3-none-any.whl", hash = "sha256:758cfddf1180053b7613db76fad3d246a331a2a905808e1164a275621fc983b8", size = 408890, upload-time = "2026-04-22T07:37:25.965Z" },
+]
+
+[[package]]
+name = "mlx-metal"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/ef/d74ae99cfe9ddb59fd08abd14f47754c3d199291a93756903fa595b31b8a/mlx_metal-0.32.0-py3-none-macosx_14_0_arm64.whl", hash = "sha256:5b64b20ac24b0c401f489de01e8209edc4d372125201f19314e6f39e385322aa", size = 40824649, upload-time = "2026-07-07T17:55:20.7Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/38/b96a3de98cfbb009592b3870af46ff63657b192f8d1e06c6c1faea5fbef3/mlx_metal-0.32.0-py3-none-macosx_15_0_arm64.whl", hash = "sha256:1bd94a1ce5b03a0c898771a3e759f0124300c6ab5155127906a1d50b1f3fcf19", size = 40818869, upload-time = "2026-07-07T17:55:25.059Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/59/65d32520175379df33f107749193aa94ea9db069167a36a1a100ff689f62/mlx_metal-0.32.0-py3-none-macosx_26_0_arm64.whl", hash = "sha256:3af76a498d84804f66119800499f9d143d7dffb0878a0dd0d7c2846e58565fd7", size = 56511379, upload-time = "2026-07-07T17:55:36.045Z" },
+]
+
+[[package]]
+name = "mlx-vlm"
+version = "0.6.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastapi" },
+    { name = "llguidance" },
+    { name = "miniaudio" },
+    { name = "mlx" },
+    { name = "mlx-audio" },
+    { name = "mlx-lm" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "python-multipart" },
+    { name = "requests" },
+    { name = "starlette" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/a3/8ee5bbc0c32a061bda3fe17873f81d7b85c7fe2ceb39daacccb1caad7671/mlx_vlm-0.6.8.tar.gz", hash = "sha256:acbd4f2652a61e71c0942177b9570331d3ed2d654c4f60f4e356680721bc09c2", size = 1654754, upload-time = "2026-07-27T19:33:51.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/6d/8ce3e2874e98e2e9b1a1d0331d5766a916bf63031ef9857ba76ed630d22a/mlx_vlm-0.6.8-py3-none-any.whl", hash = "sha256:5250c8245076e576274009b3c6c9ecd6672c686aeede5ed03e9b61ee836dac4f", size = 2090215, upload-time = "2026-07-27T19:33:50.196Z" },
+]
+
+[[package]]
 name = "model-hosting-container-standards"
 version = "0.1.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastapi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "httpx", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "jmespath", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "supervisor", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "jmespath" },
+    { name = "pydantic" },
+    { name = "setuptools" },
+    { name = "starlette" },
+    { name = "supervisor" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2d/5f/bc0d0fce1bd0a35378696aa13b21feffa18d9cda837f4e1be124e45ee090/model_hosting_container_standards-0.1.16.tar.gz", hash = "sha256:d34589633900e53c3ee5f7c78280a7cf7e4f6532c35e763341a262fc85cbe84a", size = 94130, upload-time = "2026-06-15T21:29:34.771Z" }
 wheels = [
@@ -1518,7 +1622,7 @@ name = "multiprocess"
 version = "0.70.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "dill" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/ae/04f39c5d0d0def03247c2893d6f2b83c136bf3320a2154d7b8858f2ba72d/multiprocess-0.70.16.tar.gz", hash = "sha256:161af703d4652a0e1410be6abccecde4a7ddffd19341be0a7011b94aeb171ac1", size = 1772603, upload-time = "2024-01-28T18:52:34.85Z" }
 wheels = [
@@ -1561,8 +1665,8 @@ name = "numba"
 version = "0.65.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "llvmlite", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "llvmlite" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/61/7299643b9c18d669e04be7c5bcb64d985070d07553274817b45b049e7bfe/numba-0.65.0.tar.gz", hash = "sha256:edad0d9f6682e93624c00125a471ae4df186175d71fd604c983c377cdc03e68b", size = 2764131, upload-time = "2026-04-01T03:52:01.946Z" }
 wheels = [
@@ -1639,9 +1743,9 @@ name = "nvidia-cuda-nvcc"
 version = "13.2.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-crt", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvvm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-crt" },
+    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-nvvm" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/0f/c7c7d538c61794130e759ad74710ab5aa8cab1f700ee1754381f8c665605/nvidia_cuda_nvcc-13.2.78-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c3bd144dd9b6b25e062589acb7bbd43d93d3120c72fad71da808f9817aba1239", size = 44040318, upload-time = "2026-04-13T09:42:50.457Z" },
@@ -1668,8 +1772,8 @@ name = "nvidia-cuda-tileiras"
 version = "13.2.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvcc", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvvm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc" },
+    { name = "nvidia-nvvm" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/b8/c8a96862268943c7cf30a014fe2d8f70c651d30fbfa790d54c3e347b6fa1/nvidia_cuda_tileiras-13.2.78-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ce7c140a518aa8dfe033e7176f593617ed2fece0e50331e2a14dafd236723fd", size = 36970479, upload-time = "2026-04-13T09:48:49.919Z" },
@@ -1680,7 +1784,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
@@ -1699,7 +1803,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
@@ -1726,9 +1830,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
@@ -1739,7 +1843,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
@@ -1758,7 +1862,7 @@ name = "nvidia-cutlass-dsl"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cutlass-dsl-libs-base", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cutlass-dsl-libs-base" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f0/15/575d7df4fe2f3406f1cfc68be72aeff2834f8a696daf1cd5bee8017e4507/nvidia_cutlass_dsl-4.5.2-py3-none-any.whl", hash = "sha256:68ed1b63ca74aae87955012da9dfd7fdaae471329d0028b229b841c7192ccf52", size = 10179, upload-time = "2026-05-25T03:38:56.364Z" },
@@ -1766,7 +1870,7 @@ wheels = [
 
 [package.optional-dependencies]
 cu13 = [
-    { name = "nvidia-cutlass-dsl-libs-cu13", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cutlass-dsl-libs-cu13" },
 ]
 
 [[package]]
@@ -1774,9 +1878,9 @@ name = "nvidia-cutlass-dsl-libs-base"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-python", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-python" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/e0/78eded54b4478ec01a91c75f1b9bc6dc73a2ec205c4fa2fdc25a456f4089/nvidia_cutlass_dsl_libs_base-4.5.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:9117900cba53d3c21a8dacba6bbf3d6e5f269e427a526c320fb44707a0d57363", size = 74511501, upload-time = "2026-05-25T03:52:03.798Z" },
@@ -1787,10 +1891,10 @@ name = "nvidia-cutlass-dsl-libs-cu13"
 version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-python", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cutlass-dsl-libs-base", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-python" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cutlass-dsl-libs-base" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/3d/2153608b1f8f594ccfc67daa45a1d0ff600b9e552b1e5662644e6e3ebec3/nvidia_cutlass_dsl_libs_cu13-4.5.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:df61430d6110eea872acb39257042814bf02dcbb1f8d55ea0c5681bb7ce5836a", size = 78759970, upload-time = "2026-05-25T03:43:46.762Z" },
@@ -1850,12 +1954,12 @@ name = "onnxruntime"
 version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "flatbuffers", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "protobuf", version = "7.35.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "packaging" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "protobuf", version = "7.35.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
@@ -1867,14 +1971,14 @@ name = "openai"
 version = "2.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "distro", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "httpx", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "jiter", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "sniffio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/fa/88d0c58a0c58df7e6758e66b99c5d028d5e0bb49f8812d7203940cd9dbf1/openai-2.43.0.tar.gz", hash = "sha256:e74d238200a26868977002190fb6631613480a93dfe0c9c982e77021ed60a017", size = 785369, upload-time = "2026-06-17T17:06:56.06Z" }
 wheels = [
@@ -1886,7 +1990,7 @@ name = "openai-harmony"
 version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pydantic" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/92/2d038d096f29179c7c9571b431f9e739f87a487121901725e23fe338dd9d/openai_harmony-0.0.8.tar.gz", hash = "sha256:6e43f98e6c242fa2de6f8ea12eab24af63fa2ed3e89c06341fb9d92632c5cbdf", size = 284777, upload-time = "2025-11-05T19:07:06.727Z" }
 wheels = [
@@ -1895,11 +1999,24 @@ wheels = [
 ]
 
 [[package]]
+name = "opencv-python"
+version = "5.0.0.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4c/a438d23e09ce2033c09f7b784ad2fbdb0adf529e434101ed28f142226f98/opencv_python-5.0.0.93.tar.gz", hash = "sha256:66aac3e5b5faa48d4025816592f3af19e4bfc2c68dec067bae2dbb4ca10aa9e2", size = 81802749, upload-time = "2026-07-02T06:59:53.815Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/75/76f6ade78f6102c61034f828e2a22616708df2c9504bc8d6af9dd8f73dc5/opencv_python-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:198a75138241810206a17c829dbcc40a7cb1841cda538ca86cbbfc6c7d95f898", size = 48322443, upload-time = "2026-07-02T05:50:25.466Z" },
+    { url = "https://files.pythonhosted.org/packages/15/8c/bc1bda6aae69a32e9d84fc34153ba104cd25226861eb4aea33b2cea4860d/opencv_python-5.0.0.93-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:6bbc32f59e1b1a7db7b39c81f63d00625f041d333037fd8702f6da52cc39108b", size = 34782755, upload-time = "2026-07-02T05:51:30.556Z" },
+]
+
+[[package]]
 name = "opencv-python-headless"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22", size = 56016764, upload-time = "2026-02-05T10:26:48.904Z" },
@@ -1911,7 +2028,7 @@ name = "opentelemetry-api"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
 wheels = [
@@ -1923,8 +2040,8 @@ name = "opentelemetry-exporter-otlp"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-exporter-otlp-proto-http", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/94/8637919a5d01f81dacf510234bc0110b944f4687a6e96b0a02adf2f6bdce/opentelemetry_exporter_otlp-1.42.1.tar.gz", hash = "sha256:2d9ebaed714377a67d224d46795ddcc11d2c877fa5de35fda70b6f3b010729a9", size = 6086, upload-time = "2026-05-21T16:32:51.963Z" }
 wheels = [
@@ -1936,7 +2053,7 @@ name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-proto", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-proto" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/9c/216acfeaedadf2e1937f4373929b20f73197c5c4a2546d4f584b7fa63813/opentelemetry_exporter_otlp_proto_common-1.42.1.tar.gz", hash = "sha256:04f1f01fb597c4249dfcd7f8b861c902c2102369d376d9d346ff38de4469a2ee", size = 21433, upload-time = "2026-05-21T16:32:55.526Z" }
 wheels = [
@@ -1948,13 +2065,13 @@ name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "grpcio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-api", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-exporter-otlp-proto-common", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-proto", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/87/87/ca7fc790dfdbcf4f9e9aab14a39ef1b7508ead13707e283de0b3131478d2/opentelemetry_exporter_otlp_proto_grpc-1.42.1.tar.gz", hash = "sha256:975c4461f167dd8ed8857d68d3b6b25f3d272eab896f6a9470d0f5b90e2faf15", size = 27140, upload-time = "2026-05-21T16:32:56.162Z" }
 wheels = [
@@ -1966,13 +2083,13 @@ name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-api", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-exporter-otlp-proto-common", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-proto", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/32/826bfa1d80ecea24f47808de03cd4a0d13c17ecc07712f45123f0f61e4ac/opentelemetry_exporter_otlp_proto_http-1.42.1.tar.gz", hash = "sha256:bf142a21035d7571ac3a09cb2e5639f49886f243972883cfe777ed3bf02b734d", size = 25406, upload-time = "2026-05-21T16:32:56.807Z" }
 wheels = [
@@ -1984,7 +2101,7 @@ name = "opentelemetry-proto"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b4/55/63eac3e1089b768ba014091fdd2ae8a9a440c821ef5e2b786909c94c8836/opentelemetry_proto-1.42.1.tar.gz", hash = "sha256:c6a51e6b4f05ae63565f3a113217f3d2bfaec68f78c02d7a6c85f9010d1cfca6", size = 45839, upload-time = "2026-05-21T16:33:03.937Z" }
 wheels = [
@@ -1996,9 +2113,9 @@ name = "opentelemetry-sdk"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-semantic-conventions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/f7/b390bd9bfd703bf98a68fea1f27786c6872331fd617164a54b8a59bdc008/opentelemetry_sdk-1.42.1.tar.gz", hash = "sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7", size = 239262, upload-time = "2026-05-21T16:33:04.641Z" }
 wheels = [
@@ -2010,8 +2127,8 @@ name = "opentelemetry-semantic-conventions"
 version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/93/99/4d7dd6df64795951413ce6e815f8cf1eb191daf7196ae86574589643d5f3/opentelemetry_semantic_conventions-0.63b1.tar.gz", hash = "sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9", size = 148340, upload-time = "2026-05-21T16:33:05.455Z" }
 wheels = [
@@ -2023,8 +2140,8 @@ name = "opentelemetry-semantic-conventions-ai"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-semantic-conventions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/02/10aeacc37a38a3a8fa16ff67bec1ae3bf882539f6f9efb0f70acf802ca2d/opentelemetry_semantic_conventions_ai-0.5.1.tar.gz", hash = "sha256:153906200d8c1d2f8e09bd78dbef526916023de85ac3dab35912bfafb69ff04c", size = 26533, upload-time = "2026-03-26T14:20:38.73Z" }
 wheels = [
@@ -2081,11 +2198,11 @@ name = "pandas"
 version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "python-dateutil", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pytz", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tzdata", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213, upload-time = "2024-09-20T13:10:04.827Z" }
 wheels = [
@@ -2118,17 +2235,17 @@ name = "peft"
 version = "0.15.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "accelerate", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "huggingface-hub", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "psutil", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "safetensors", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "torch", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "transformers", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "accelerate" },
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/65/faa18cd8ffbe0f742c3f2559770646cce2574b9cd28a2a05e8d36f64e968/peft-0.15.2.tar.gz", hash = "sha256:7059029f4d42a092ded1aa117dd366a46084aef638bdd593f6ab0195d5427fcd", size = 472952, upload-time = "2025-04-15T15:27:53.09Z" }
 wheels = [
@@ -2141,9 +2258,13 @@ version = "12.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/e1/748f5663efe6edcfc4e74b2b93edfb9b8b99b67f21a854c3ae416500a2d9/pillow-12.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:8be29e59487a79f173507c30ddf57e733a357f67881430449bb32614075a40ab", size = 5354347, upload-time = "2026-04-01T14:42:44.255Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a1/d5ff69e747374c33a3b53b9f98cca7889fce1fd03d79cdc4e1bccc6c5a87/pillow-12.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71cde9a1e1551df7d34a25462fc60325e8a11a82cc2e2f54578e5e9a1e153d65", size = 4695873, upload-time = "2026-04-01T14:42:46.452Z" },
     { url = "https://files.pythonhosted.org/packages/d3/f1/00b7278c7dd52b17ad4329153748f87b6756ec195ff786c2bdf12518337d/pillow-12.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8bd7903a5f2a4545f6fd5935c90058b89d30045568985a71c79f5fd6edf9b91e", size = 8088188, upload-time = "2026-04-01T14:42:51.735Z" },
     { url = "https://files.pythonhosted.org/packages/e9/bd/e51a61b1054f09437acfbc2ff9106c30d1eb76bc1453d428399946781253/pillow-12.2.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e74473c875d78b8e9d5da2a70f7099549f9eb37ded4e2f6a463e60125bccd176", size = 7079655, upload-time = "2026-04-01T14:42:56.954Z" },
     { url = "https://files.pythonhosted.org/packages/7d/2e/9df2fc1e82097b1df3dce58dc43286aa01068e918c07574711fcc53e6fb4/pillow-12.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:90e6f81de50ad6b534cab6e5aef77ff6e37722b2f5d908686f4a5c9eba17a909", size = 7203402, upload-time = "2026-04-01T14:43:02.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b7/2437044fb910f499610356d1352e3423753c98e34f915252aafecc64889f/pillow-12.2.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0538bd5e05efec03ae613fd89c4ce0368ecd2ba239cc25b9f9be7ed426b0af1f", size = 5273969, upload-time = "2026-04-01T14:45:55.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f4/8316e31de11b780f4ac08ef3654a75555e624a98db1056ecb2122d008d5a/pillow-12.2.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:394167b21da716608eac917c60aa9b969421b5dcbbe02ae7f013e7b85811c69d", size = 4659674, upload-time = "2026-04-01T14:45:58.093Z" },
     { url = "https://files.pythonhosted.org/packages/49/62/5b0ed78fce87346be7a5cfcfaaad91f6a1f98c26f86bdbafa2066c647ef6/pillow-12.2.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0c838a5125cee37e68edec915651521191cef1e6aa336b855f495766e77a366e", size = 7032230, upload-time = "2026-04-01T14:46:03.874Z" },
     { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
 ]
@@ -2162,7 +2283,7 @@ name = "pip-api"
 version = "0.0.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pip", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "pip" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/f1/ee85f8c7e82bccf90a3c7aad22863cc6e20057860a1361083cd2adacb92e/pip_api-0.0.34.tar.gz", hash = "sha256:9b75e958f14c5a2614bae415f2adf7eeb54d50a2cfbe7e24fd4826471bac3625", size = 123017, upload-time = "2024-07-09T20:32:30.641Z" }
 wheels = [
@@ -2174,16 +2295,16 @@ name = "pip-audit"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cachecontrol", extra = ["filecache"], marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "cyclonedx-python-lib", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pip-api", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pip-requirements-parser", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "platformdirs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "requests", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "rich", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tomli", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tomli-w", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "cachecontrol", extra = ["filecache"] },
+    { name = "cyclonedx-python-lib" },
+    { name = "packaging" },
+    { name = "pip-api" },
+    { name = "pip-requirements-parser" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a4/f21d5f0a0edabcbce31560b73c7c5a6f72ae87af4236fd1069c8f59a353d/pip_audit-2.10.1.tar.gz", hash = "sha256:1eb4565d19ebe5d48996f4b770b4d2b32887e12cb12cfa637f1a064011b55ffc", size = 54275, upload-time = "2026-06-10T22:17:01.744Z" }
 wheels = [
@@ -2195,8 +2316,8 @@ name = "pip-requirements-parser"
 version = "32.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyparsing", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pyparsing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/2a/63b574101850e7f7b306ddbdb02cb294380d37948140eecd468fae392b54/pip-requirements-parser-32.0.1.tar.gz", hash = "sha256:b4fa3a7a0be38243123cf9d1f3518da10c51bdb165a2b2985566247f9155a7d3", size = 209359, upload-time = "2022-12-21T15:25:22.732Z" }
 wheels = [
@@ -2226,11 +2347,11 @@ name = "pre-commit"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cfgv", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "identify", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "nodeenv", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "virtualenv", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
@@ -2251,8 +2372,8 @@ name = "prometheus-fastapi-instrumentator"
 version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "prometheus-client", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "prometheus-client" },
+    { name = "starlette" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/7a/fe49b7060e585e2cfa28cc1d13ebfe9c2904dcd80cf11071d5de0f622ff2/prometheus_fastapi_instrumentator-8.0.0.tar.gz", hash = "sha256:c31ed192db077e75467b28b2fe5055362517f53369b798cb8dac9ff85f3f1c38", size = 20357, upload-time = "2026-05-29T13:04:43.327Z" }
 wheels = [
@@ -2325,7 +2446,7 @@ name = "py-serializable"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "defusedxml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "defusedxml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/73/21/d250cfca8ff30c2e5a7447bc13861541126ce9bd4426cd5d0c9f08b5547d/py_serializable-2.1.0.tar.gz", hash = "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103", size = 52368, upload-time = "2025-07-21T09:56:48.07Z" }
 wheels = [
@@ -2379,10 +2500,10 @@ name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-types", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pydantic-core", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "typing-inspection", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -2391,7 +2512,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -2399,7 +2520,7 @@ name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
@@ -2421,8 +2542,8 @@ name = "pydantic-extra-types"
 version = "2.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
 wheels = [
@@ -2431,7 +2552,7 @@ wheels = [
 
 [package.optional-dependencies]
 pycountry = [
-    { name = "pycountry", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pycountry" },
 ]
 
 [[package]]
@@ -2439,9 +2560,9 @@ name = "pydantic-settings"
 version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "python-dotenv", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-inspection", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
@@ -2477,7 +2598,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -2485,8 +2606,8 @@ name = "pymdown-extensions"
 version = "11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "markdown" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
 wheels = [
@@ -2507,10 +2628,10 @@ name = "pytest"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "iniconfig", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pluggy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pygments", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
@@ -2522,7 +2643,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -2534,8 +2655,8 @@ name = "python-discovery"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "platformdirs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "platformdirs" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
 wheels = [
@@ -2595,7 +2716,7 @@ name = "pyyaml-env-tag"
 version = "1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
@@ -2607,7 +2728,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -2623,11 +2744,11 @@ name = "quack-kernels"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cutlass-dsl", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch-c-dlpack-ext", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "apache-tvm-ffi" },
+    { name = "einops" },
+    { name = "nvidia-cutlass-dsl" },
+    { name = "torch" },
+    { name = "torch-c-dlpack-ext" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e1/94/ee76e3a3dc74d986b7b24c5928f1d14b01bd5152375688c2ede369f6d19b/quack_kernels-0.5.0.tar.gz", hash = "sha256:c7c7338b67243397b6ca166e648bba161076e99f3858b532e1c877dcc6eaa03d", size = 366426, upload-time = "2026-05-29T05:00:25.985Z" }
 wheels = [
@@ -2639,9 +2760,9 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "rpds-py", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -2666,10 +2787,10 @@ name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "charset-normalizer", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "idna", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "urllib3", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
@@ -2681,8 +2802,8 @@ name = "rich"
 version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pygments", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "markdown-it-py" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload-time = "2024-11-01T16:43:57.873Z" }
 wheels = [
@@ -2694,9 +2815,9 @@ name = "rich-toolkit"
 version = "0.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "rich", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/29/63/3e427c62f1992945c997d4ec31e2fcb37d26aadbe5aa44ae5b29f7f64d26/rich_toolkit-0.20.1.tar.gz", hash = "sha256:c7336ae281f435c785acecaedc4b71d4b663dc73d9c8079fea96372527e822a4", size = 203473, upload-time = "2026-06-05T08:56:57.679Z" }
 wheels = [
@@ -2741,14 +2862,29 @@ wheels = [
 
 [[package]]
 name = "safetensors"
-version = "0.6.2"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ac/cc/738f3011628920e027a11754d9cae9abec1aed00f7ae860abbf843755233/safetensors-0.6.2.tar.gz", hash = "sha256:43ff2aa0e6fa2dc3ea5524ac7ad93a9839256b8703761e76e2d0b2a3fa4f15d9", size = 197968, upload-time = "2025-08-08T13:13:58.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/b1/3f5fd73c039fc87dba3ff8b5d528bfc5a32b597fea8e7a6a4800343a17c7/safetensors-0.6.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9c85ede8ec58f120bad982ec47746981e210492a6db876882aa021446af8ffba", size = 454797, upload-time = "2025-08-08T13:13:52.066Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/c9/bb114c158540ee17907ec470d01980957fdaf87b4aa07914c24eba87b9c6/safetensors-0.6.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d6675cf4b39c98dbd7d940598028f3742e0375a6b4d4277e76beb0c35f4b843b", size = 432206, upload-time = "2025-08-08T13:13:50.931Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/5d/5a514d7b88e310c8b146e2404e0dc161282e78634d9358975fd56dfd14be/safetensors-0.6.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8045db2c872db8f4cbe3faa0495932d89c38c899c603f21e9b6486951a5ecb8f", size = 485835, upload-time = "2025-08-08T13:13:49.373Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/fe/cad1d9762868c7c5dc70c8620074df28ebb1a8e4c17d4c0cb031889c457e/safetensors-0.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d944cea65fad0ead848b6ec2c37cc0b197194bec228f8020054742190e9312ac", size = 655957, upload-time = "2025-08-08T13:13:57.029Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
 ]
 
 [[package]]
@@ -2768,8 +2904,8 @@ name = "sentry-sdk"
 version = "2.63.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "urllib3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "certifi" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ba/c8/b3c970a5b186722d276cd40a05b3254e03bccc0208560aff20f612e018e8/sentry_sdk-2.63.0.tar.gz", hash = "sha256:2a1502bf864769275dbc8c2c9fc7a0f7f5e18358180b615d262d13a31ffba216", size = 912449, upload-time = "2026-06-16T12:45:57.553Z" }
 wheels = [
@@ -2833,12 +2969,25 @@ wheels = [
 ]
 
 [[package]]
+name = "sounddevice"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/f9/2592608737553638fca98e21e54bfec40bf577bb98a61b2770c912aab25e/sounddevice-0.5.5.tar.gz", hash = "sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3", size = 143191, upload-time = "2026-01-23T18:36:43.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/0a/478e441fd049002cf308520c0d62dd8333e7c6cc8d997f0dda07b9fbcc46/sounddevice-0.5.5-py3-none-any.whl", hash = "sha256:30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f", size = 32807, upload-time = "2026-01-23T18:36:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f9/c037c35f6d0b6bc3bc7bfb314f1d6f1f9a341328ef47cd63fc4f850a7b27/sounddevice-0.5.5-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:05eb9fd6c54c38d67741441c19164c0dae8ce80453af2d8c4ad2e7823d15b722", size = 108557, upload-time = "2026-01-23T18:36:37.41Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "anyio" },
+    { name = "starlette" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
 wheels = [
@@ -2850,8 +2999,8 @@ name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "anyio" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
@@ -2872,7 +3021,7 @@ name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mpmath", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "mpmath" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
@@ -2902,8 +3051,8 @@ name = "tiktoken"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "regex", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "regex" },
+    { name = "requests" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/02/576ff3a6639e755c4f70997b2d315f56d6d71e0d046f4fb64cb81a3fb099/tiktoken-0.8.0.tar.gz", hash = "sha256:9ccbb2740f24542534369c5635cfd9b2b3c2490754a78ac8831d99f89f94eeb2", size = 35107, upload-time = "2024-10-03T22:44:04.196Z" }
 wheels = [
@@ -2916,16 +3065,16 @@ name = "tilelang"
 version = "0.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "cloudpickle", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "ml-dtypes", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "psutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch-c-dlpack-ext", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "z3-solver", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "apache-tvm-ffi" },
+    { name = "cloudpickle" },
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "psutil" },
+    { name = "torch" },
+    { name = "torch-c-dlpack-ext" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "z3-solver" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/70/5051f65821baa30a3d61fc48f8ba10c776490315e8c90f82559b92089756/tilelang-0.1.9.tar.gz", hash = "sha256:287f727c913bb648fcf6c1968809ba3390e55eeed257a5c6bb9a80bc05966af4", size = 93395292, upload-time = "2026-04-22T09:19:11.988Z" }
 wheels = [
@@ -2937,7 +3086,7 @@ name = "tokenizers"
 version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "huggingface-hub" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/46/fb6854cec3278fbfa4a75b50232c77622bc517ac886156e6afbfa4d8fc6e/tokenizers-0.22.1.tar.gz", hash = "sha256:61de6522785310a309b3407bac22d99c4db5dba349935e99e4d15ea2226af2d9", size = 363123, upload-time = "2025-09-19T09:49:23.424Z" }
 wheels = [
@@ -2952,10 +3101,10 @@ name = "tokenspeed-mla"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cutlass-dsl", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tokenspeed-triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "apache-tvm-ffi" },
+    { name = "nvidia-cutlass-dsl" },
+    { name = "tokenspeed-triton" },
+    { name = "torch" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/01/4bf8b74ead3e8e7c1c809435396254c067a33fde48acc20f602aae622d97/tokenspeed_mla-0.1.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:c9466a351fe039792e56cf49f3e79744c1dc28c7af10306a02e62b8e92fa5985", size = 748681, upload-time = "2026-05-13T03:30:56.718Z" },
@@ -2997,20 +3146,20 @@ name = "torch"
 version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "filelock", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "networkx", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "nvidia-cudnn-cu13", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "sympy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/0d/98b410492609e34a155fa8b121b55c7dca229f39636851c3a9ec20edea21/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7b6a60d48062809f58595509c524b88e6ddec3ebe25833d6462eeab81e5f2ce4", size = 80529712, upload-time = "2026-03-23T18:12:02.608Z" },
@@ -3022,7 +3171,7 @@ name = "torch-c-dlpack-ext"
 version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/37/de/921b6491efce5c389a5ef9bbed3d2d6660005840dae488124173180859ab/torch_c_dlpack_ext-0.1.5.tar.gz", hash = "sha256:d06f0357d575d22a168cc77acb9020fc4bae30968ceb6718a055dcbe92bacabe", size = 12913, upload-time = "2026-01-12T11:25:08.484Z" }
 wheels = [
@@ -3042,9 +3191,9 @@ name = "torchvision"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pillow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "pillow" },
+    { name = "torch" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/45/57bbf9e216850d065e66dd31a50f57424b607f1d878ab8956e56a1f4e36b/torchvision-0.26.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:fd10b5f994c210f4f6d6761cf686f82d748554adf486cb0979770c3252868c8f", size = 7519925, upload-time = "2026-03-23T18:12:53.283Z" },
@@ -3061,23 +3210,23 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.6.2"
+version = "5.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "packaging", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "regex", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "safetensors", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tokenizers", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "typer", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/e9/c6c80a07690142a7d05444271f47b9f3c8aac7dea01d52e1137ee480ad78/transformers-5.6.2.tar.gz", hash = "sha256:e657134c3e5a6bc00a3c35f4e2674bb51adfcd89898495b788a18552bac2b91a", size = 8311867, upload-time = "2026-04-23T18:33:29.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/fb/2a2ba88f325e68a921d8b69ff63b477830b2e73ade9a3c8c8cab2f06d741/transformers-5.14.1.tar.gz", hash = "sha256:60d196c27781eacf8637e2b533f517582907ad6f9ae142046d6b69431a5b2173", size = 9295927, upload-time = "2026-07-16T09:41:57.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/0b0218149b0d6f14df35f5b8f676fa83df4f19ed253c3cc447107ef86eca/transformers-5.6.2-py3-none-any.whl", hash = "sha256:f8d3a1bb96778fed9b8aabfd0dd6e19843e4b0f2bb6b59f32b8a92051b0f348f", size = 10364898, upload-time = "2026-04-23T18:33:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/67/8d85ca2323233ae3c0365a659c4e52ee1f587b440e4bc577e7d8e4416d0f/transformers-5.14.1-py3-none-any.whl", hash = "sha256:9db974c4079ede2d1a3ea7ca5a240df33f2cc26fc2b36ba64c5f2a4f43b6e725", size = 11625234, upload-time = "2026-07-16T09:41:54.143Z" },
 ]
 
 [[package]]
@@ -3085,60 +3234,66 @@ name = "trialmatchai"
 version = "0.7.0"
 source = { editable = "." }
 dependencies = [
-    { name = "lancedb", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
-    { name = "pandas", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyarrow", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pydantic", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "python-dateutil", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "python-dotenv", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "requests", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tenacity", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "lancedb" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tenacity" },
+    { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
 entity = [
-    { name = "gliner2", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "torch", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "transformers", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "gliner2" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 finetune = [
-    { name = "accelerate", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "bitsandbytes", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "datasets", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "gliner2", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "peft", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "torch", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "transformers", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "accelerate" },
+    { name = "bitsandbytes", marker = "sys_platform == 'linux'" },
+    { name = "datasets" },
+    { name = "gliner2" },
+    { name = "peft" },
+    { name = "torch" },
+    { name = "transformers" },
 ]
 gpu = [
-    { name = "bitsandbytes", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "vllm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "bitsandbytes", marker = "sys_platform == 'linux'" },
+    { name = "vllm", marker = "sys_platform == 'linux'" },
 ]
 llm = [
-    { name = "accelerate", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "einops", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "peft", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "safetensors", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "sentencepiece", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "tokenizers", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "torch", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "transformers", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "accelerate" },
+    { name = "einops" },
+    { name = "peft" },
+    { name = "safetensors" },
+    { name = "sentencepiece" },
+    { name = "tokenizers" },
+    { name = "torch" },
+    { name = "transformers" },
+]
+mlx = [
+    { name = "mlx-lm", marker = "sys_platform != 'linux'" },
+]
+mlx-vlm = [
+    { name = "mlx-vlm", marker = "sys_platform != 'linux'" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "pip-audit", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pre-commit", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "pytest", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "ruff", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "pip-audit" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "ruff" },
 ]
 docs = [
-    { name = "mkdocs-material", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "mkdocstrings", extra = ["python"], marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
 ]
 
 [package.metadata]
@@ -3152,6 +3307,8 @@ requires-dist = [
     { name = "gliner2", marker = "extra == 'entity'", specifier = ">=1.3.1,<2" },
     { name = "gliner2", marker = "extra == 'finetune'", specifier = ">=1.3.1,<2" },
     { name = "lancedb", specifier = ">=0.25.0,<0.26" },
+    { name = "mlx-lm", marker = "sys_platform == 'darwin' and extra == 'mlx'", specifier = ">=0.26" },
+    { name = "mlx-vlm", marker = "sys_platform == 'darwin' and extra == 'mlx-vlm'", specifier = ">=0.6" },
     { name = "numpy", specifier = ">=2.0,<3" },
     { name = "pandas", specifier = "==2.2.3" },
     { name = "peft", marker = "extra == 'finetune'", specifier = "==0.15.2" },
@@ -3162,7 +3319,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0,<2" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "requests", specifier = "==2.34.2" },
-    { name = "safetensors", marker = "extra == 'llm'", specifier = ">=0.6.2,<0.7" },
+    { name = "safetensors", marker = "extra == 'llm'", specifier = ">=0.8.0,<1" },
     { name = "sentencepiece", marker = "extra == 'llm'", specifier = "==0.2.1" },
     { name = "tenacity", specifier = "==9.0.0" },
     { name = "tokenizers", marker = "extra == 'llm'", specifier = "==0.22.1" },
@@ -3170,12 +3327,12 @@ requires-dist = [
     { name = "torch", marker = "extra == 'finetune'", specifier = "==2.11.0" },
     { name = "torch", marker = "extra == 'llm'", specifier = "==2.11.0" },
     { name = "tqdm", specifier = "==4.67.1" },
-    { name = "transformers", marker = "extra == 'entity'", specifier = "==5.6.2" },
-    { name = "transformers", marker = "extra == 'finetune'", specifier = "==5.6.2" },
-    { name = "transformers", marker = "extra == 'llm'", specifier = "==5.6.2" },
+    { name = "transformers", marker = "extra == 'entity'", specifier = ">=5.14.0,<6" },
+    { name = "transformers", marker = "extra == 'finetune'", specifier = ">=5.14.0,<6" },
+    { name = "transformers", marker = "extra == 'llm'", specifier = ">=5.14.0,<6" },
     { name = "vllm", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = "==0.23.0" },
 ]
-provides-extras = ["gpu", "llm", "entity", "finetune"]
+provides-extras = ["gpu", "llm", "entity", "mlx", "mlx-vlm", "finetune"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3202,10 +3359,10 @@ name = "typer"
 version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "click", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "rich", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "shellingham", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
@@ -3226,7 +3383,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -3256,8 +3413,8 @@ name = "uvicorn"
 version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "h11", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "click" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
@@ -3266,12 +3423,12 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "httptools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "python-dotenv", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "uvloop", marker = "platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux'" },
-    { name = "watchfiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "websockets", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
 ]
 
 [[package]]
@@ -3289,10 +3446,10 @@ name = "virtualenv"
 version = "21.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "distlib", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "filelock", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "platformdirs", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "python-discovery", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
 wheels = [
@@ -3304,75 +3461,75 @@ name = "vllm"
 version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "anthropic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "apache-tvm-ffi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "blake3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "cachetools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "cbor2", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "cloudpickle", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "compressed-tensors", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "depyf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "diskcache", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "fastapi", extra = ["standard"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "fastsafetensors", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "filelock", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "flashinfer-cubin", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "flashinfer-python", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "gguf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "humming-kernels", extra = ["cu13"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "ijson", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "lark", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "llguidance", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "lm-format-enforcer", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "mcp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "mistral-common", extra = ["image"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "model-hosting-container-standards", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "msgspec", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "ninja", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numba", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-frontend", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cutlass-dsl", extra = ["cu13"], marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "openai", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "openai-harmony", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opencv-python-headless", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-api", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-exporter-otlp", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-sdk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "opentelemetry-semantic-conventions-ai", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "outlines-core", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "partial-json-parser", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pillow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "prometheus-client", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "prometheus-fastapi-instrumentator", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "psutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "py-cpuinfo", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pybase64", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "python-json-logger", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pyzmq", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "quack-kernels", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "regex", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "safetensors", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "sentencepiece", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setproctitle", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tiktoken", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tilelang", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tokenizers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tokenspeed-mla", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torchaudio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torchvision", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "transformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "watchfiles", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "xgrammar", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "aiohttp" },
+    { name = "anthropic" },
+    { name = "apache-tvm-ffi" },
+    { name = "blake3" },
+    { name = "cachetools" },
+    { name = "cbor2" },
+    { name = "cloudpickle" },
+    { name = "compressed-tensors" },
+    { name = "depyf" },
+    { name = "diskcache" },
+    { name = "einops" },
+    { name = "fastapi", extra = ["standard"] },
+    { name = "fastsafetensors" },
+    { name = "filelock" },
+    { name = "flashinfer-cubin" },
+    { name = "flashinfer-python" },
+    { name = "gguf" },
+    { name = "humming-kernels", extra = ["cu13"] },
+    { name = "ijson" },
+    { name = "lark" },
+    { name = "llguidance" },
+    { name = "lm-format-enforcer" },
+    { name = "mcp" },
+    { name = "mistral-common", extra = ["image"] },
+    { name = "model-hosting-container-standards" },
+    { name = "msgspec" },
+    { name = "ninja" },
+    { name = "numba" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cudnn-frontend" },
+    { name = "nvidia-cutlass-dsl", extra = ["cu13"] },
+    { name = "openai" },
+    { name = "openai-harmony" },
+    { name = "opencv-python-headless" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions-ai" },
+    { name = "outlines-core" },
+    { name = "partial-json-parser" },
+    { name = "pillow" },
+    { name = "prometheus-client" },
+    { name = "prometheus-fastapi-instrumentator" },
+    { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "psutil" },
+    { name = "py-cpuinfo" },
+    { name = "pybase64" },
+    { name = "pydantic" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "pyzmq" },
+    { name = "quack-kernels" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "safetensors" },
+    { name = "sentencepiece" },
+    { name = "setproctitle" },
+    { name = "tiktoken" },
+    { name = "tilelang" },
+    { name = "tokenizers" },
+    { name = "tokenspeed-mla" },
+    { name = "torch" },
+    { name = "torchaudio" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+    { name = "xgrammar" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/68/c6/c4dc766b09e93de278693502612de0beba822983d4f609830406ead65cc9/vllm-0.23.0.tar.gz", hash = "sha256:760269db3d9611e12e524681df1bca0977d5d2f5fcb4481cc34d33efc4ae7ff5", size = 36624042, upload-time = "2026-06-13T09:27:24.297Z" }
 wheels = [
@@ -3397,7 +3554,7 @@ name = "watchfiles"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "anyio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
 wheels = [
@@ -3422,13 +3579,13 @@ name = "xgrammar"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "transformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "apache-tvm-ffi" },
+    { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic" },
+    { name = "torch" },
+    { name = "transformers" },
+    { name = "triton" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/b7/86178b241be0b29ce9ee991a44d4b7eddb0f0c98310c0067fe83afc897d1/xgrammar-0.2.2.tar.gz", hash = "sha256:42bcc5c4187ff9cb6edc44ff5f56030d8b69d62c7576f674a5a074f71b68b1fa", size = 2430492, upload-time = "2026-06-11T19:02:49.624Z" }
 wheels = [
@@ -3455,9 +3612,9 @@ name = "yarl"
 version = "1.24.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "multidict", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
-    { name = "propcache", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Use MLX-LM stream_generate first-token log probabilities for Yes/No reranking.
- Normalize the Yes/No log probabilities with a stable two-class softmax.
- Mark score provenance as binary_yes_probability and invalidate stale MLX match caches.
- Add regression coverage for probability normalization and missing-logprob handling.

## Validation

- Focused MLX and audit tests passed.
- Full pytest passed.
- ruff check passed.
- One-topic TAIM adapter smoke passed with TRIALMATCHAI_MLX_MAX_NEW_TOKENS=8192.
- Real MLX and MLX-VLM stages completed and produced parseable JSON.

Tracks TAIM issue https://github.com/hannesill/TAIM/issues/59.